### PR TITLE
fix: removing corporate email ids from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,22 +76,6 @@ If you're looking for `@gofynd/nitrozen-react` API documentation, check out:
 
 - [Storybook](https://gofynd.io/nitrozen-react/?path=/story/introduction-welcome--welcome)
 
-## 🙌 Contributors:
-
-- Kingshuk - kingshukb@gofynd.com
-- Sumit - sumitsinha@gofynd.com
-- Rushikesh - rushikeshtarapure@gofynd.com
-- Pratyush - prathyushsunny@gofynd.com
-- Sayak - sayakghosh@gofynd.com
-- Surajit - surajitdas@gofynd.com
-- Aman - amantiwari@gofynd.com
-- Rakesh - rakeshyadav1@gofynd.com
-- Sameer - sameershaikh@gofynd.com
-- Ayush - ayushjain@gofynd.com
-- Rohit - rohitgupta@gofynd.com
-- Ashutosh - ashutoshkumar@gofynd.com
-- Aadesh - aadeshkulkarni@gofynd.com
-
 ## 📝 License
 
 > Licensed under the Apache 2.0 License


### PR DESCRIPTION
receiving following email from Security centre - `fynd corporate email ids exposed in github` Please prioritise the removal of corporate email id from github repository and get the activity complete in the next 5 business days.