### PR TITLE
Feature/button-css Redesign wrt JDS guidelines

### DIFF
--- a/src/base/variable.scss
+++ b/src/base/variable.scss
@@ -59,3 +59,152 @@ $Perano: #a9b1ea;
 $Whisper3: #ededed;
 $Gray: #8f8f8f;
 $PinkSwan: #b8b8b8;
+
+////////////////////////////////////Light Theme////////////////////////////////////
+////////////////////////////////////Color////////////////////////////////////
+$ColorPrimary20: var(--ColorPrimary20, #e8e8fc);
+$ColorPrimary30: var(--ColorPrimary30, #9999ff);
+$ColorPrimary40: var(--ColorPrimary40, #6464ff);
+$ColorPrimary50: var(--ColorPrimary50, #3535f3);
+$ColorPrimary60: var(--ColorPrimary60, #000093);
+$ColorPrimary70: var(--ColorPrimary70, #00004c);
+$ColorPrimary80: var(--ColorPrimary80, #010029);
+$ColorPrimaryInverse: var(--ColorPrimaryInverse, #ffffff);
+$ColorPrimaryBackground: var(--ColorPrimaryBackground, #ffffff);
+$ColorPrimaryGrey100: var(--ColorPrimaryGrey100, #141414);
+$ColorPrimaryGrey80: var(--ColorPrimaryGrey80, rgba(0, 0, 0, 0.65));
+$ColorPrimaryGrey60: var(--ColorPrimaryGrey60, #b5b5b5);
+$ColorPrimaryGrey40: var(--ColorPrimaryGrey40, #e0e0e0);
+$ColorPrimaryGrey20: var(--ColorPrimaryGrey20, #f5f5f5);
+$ColorSecondary20: var(--ColorSecondary20, #fef7e9);
+$ColorSecondary30: var(--ColorSecondary30, #ffe3ae);
+$ColorSecondary40: var(--ColorSecondary40, #ffd947);
+$ColorSecondary50: var(--ColorSecondary50, #f7ab20);
+$ColorSecondary60: var(--ColorSecondary60, #ac660c);
+$ColorSecondary70: var(--ColorSecondary70, #7f4b10);
+$ColorSecondary80: var(--ColorSecondary80, #401d0c);
+$ColorSecondaryInverse: var(--ColorSecondaryInverse, #401d0c);
+$ColorSecondaryBackground: var(--ColorSecondaryBackground, #ffffff);
+$ColorSecondaryGrey100: var(--ColorSecondaryGrey100, #141414);
+$ColorSecondaryGrey80: var(--ColorSecondaryGrey80, rgba(0, 0, 0, 0.65));
+$ColorSecondaryGrey60: var(--ColorSecondaryGrey60, #b5b5b5);
+$ColorSecondaryGrey40: var(--ColorSecondaryGrey40, #e0e0e0);
+$ColorSecondaryGrey20: var(--ColorSecondaryGrey20, #f5f5f5);
+$ColorSparkle20: var(--ColorSparkle20, #e8faf7);
+$ColorSparkle30: var(--ColorSparkle30, #a7f6e9);
+$ColorSparkle40: var(--ColorSparkle40, #7aebd9);
+$ColorSparkle50: var(--ColorSparkle50, #1eccb0);
+$ColorSparkle60: var(--ColorSparkle60, #1e7b74);
+$ColorSparkle70: var(--ColorSparkle70, #0e5c4f);
+$ColorSparkle80: var(--ColorSparkle80, #08332c);
+$ColorSparkleInverse: var(--ColorSparkleInverse, #08332c);
+$ColorSparkleBackground: var(--ColorSparkleBackground, #ffffff);
+$ColorSparkleGrey100: var(--ColorSparkleGrey100, #141414);
+$ColorSparkleGrey80: var(--ColorSparkleGrey80, rgba(0, 0, 0, 0.65));
+$ColorSparkleGrey60: var(--ColorSparkleGrey60, #b5b5b5);
+$ColorSparkleGrey40: var(--ColorSparkleGrey40, #e0e0e0);
+$ColorSparkleGrey20: var(--ColorSparkleGrey20, #f5f5f5);
+$ColorWhite: var(--ColorWhite, #ffffff);
+$ColorBlack: var(--ColorBlack, #141414);
+$ColorFeedbackError80: var(--ColorFeedbackError80, #660014);
+$ColorFeedbackError50: var(--ColorFeedbackError50, #f50031);
+$ColorFeedbackError20: var(--ColorFeedbackError20, #fee6ea);
+$ColorFeedbackWarning80: var(--ColorFeedbackWarning80, #7d2f08);
+$ColorFeedbackWarning50: var(--ColorFeedbackWarning50, #f06d0f);
+$ColorFeedbackWarning20: var(--ColorFeedbackWarning20, #fef0e7);
+$ColorFeedbackSuccess80: var(--ColorFeedbackSuccess80, #135610);
+$ColorFeedbackSuccess50: var(--ColorFeedbackSuccess50, #25ab21);
+$ColorFeedbackSuccess20: var(--ColorFeedbackSuccess20, #e9f7e9);
+
+////////////////////////////////////Shadow////////////////////////////////////
+$ShadowS: var(--ShadowS, 0px 4px 16px rgba(0, 0, 0, 0.08));
+$ShadowM: var(--ShadowM, 0px 4px 16px rgba(0, 0, 0, 0.16));
+$ShadowL: var(--ShadowL, 0px 4px 16px rgba(0, 0, 0, 0.24));
+
+////////////////////////////////////Elevation////////////////////////////////////
+$Elevation10: var(--Elevation10, 10);
+$Elevation20: var(--Elevation20, 20);
+$Elevation30: var(--Elevation30, 30);
+$Elevation40: var(--Elevation40, 40);
+$Elevation50: var(--Elevation50, 50);
+$Elevation60: var(--Elevation60, 60);
+$Elevation70: var(--Elevation70, 70);
+
+////////////////////////////////////Surfaces////////////////////////////////////
+$SurfacesSoftBg: var(--SurfacesSoftBg, rgba(89, 89, 89, 0.5));
+$SurfacesSoftFilter: var(--SurfacesSoftFilter, blur(24px));
+$SurfacesHeavyBg: var(--SurfacesHeavyBg, rgba(89, 89, 89, 0.5));
+$SurfacesHeavyFilter: var(--SurfacesHeavyFilter, blur(64px));
+$SurfacesOverlayBg: var(--SurfacesOverlayBg, rgba(20, 20, 20, 0.4));
+$SurfacesOverlayFilter: var(--SurfacesOverlayFilter, none);
+$SurfacesBlurredBgBg: var(--SurfacesBlurredBgBg, rgba(20, 20, 20, 0.8));
+
+////////////////////////////////////Rransitions////////////////////////////////////
+$SurfacesBlurredBgFilter: var(--SurfacesBlurredBgFilter, blur(24px));
+$TransitionsDurationRapid: var(--TransitionsDurationRapid, 300ms);
+$TransitionsDurationMedium: var(--TransitionsDurationMedium, 500ms);
+$TransitionsDurationSlow: var(--TransitionsDurationSlow, 1000ms);
+$TransitionsEaseRapid: var(
+  --TransitionsEaseRapid,
+  cubic-bezier(0.35, 0, 0.5, 1)
+);
+$TransitionsEaseQuick: var(
+  --TransitionsEaseQuick,
+  cubic-bezier(0.35, 0, 0.25, 1)
+);
+$TransitionsEaseJoyful: var(
+  --TransitionsEaseJoyful,
+  cubic-bezier(0.35, 1.3, 0.3, 1)
+);
+$TransitionsEaseEntrance: var(
+  --TransitionsEaseEntrance,
+  cubic-bezier(0, 0, 0.1, 1)
+);
+$TransitionsEaseExit: var(--TransitionsEaseExit, cubic-bezier(0.35, 0, 0.8, 1));
+$TransitionsEaseJoyfulentrance: var(
+  --TransitionsEaseJoyfulentrance,
+  cubic-bezier(0.15, 1.3, 0.3, 1)
+);
+$TransitionsEaseJoyfulexit: var(
+  --TransitionsEaseJoyfulexit,
+  cubic-bezier(0.7, -0.1, 0.6, 0.1)
+);
+
+//////////////////////////////////// spacing and aspect ratio ////////////////////////////////////
+$SpacingBase: var(--SpacingBase, 1rem);
+$SpacingXxs: var(--SpacingXxs, calc($SpacingBase * 0.25));
+$SpacingXs: var(--SpacingXs, calc($SpacingBase * 0.5));
+$SpacingS: var(--SpacingS, calc($SpacingBase * 0.75));
+$SpacingM: var(--SpacingM, calc($SpacingBase * 1.5));
+$SpacingL: var(--SpacingL, calc($SpacingBase * 2));
+$SpacingXl: var(--SpacingXl, calc($SpacingBase * 2.5));
+$SpacingXxl: var(--SpacingXxl, calc($SpacingBase * 3));
+$SpacingHuge: var(--SpacingHuge, calc($SpacingBase * 4));
+$SpacingMassive: var(--SpacingMassive, calc($SpacingBase * 5));
+$ValMaxWidth: var(--ValMaxWidth, 1184px);
+$ValMaxWidthNarrow: var(--ValMaxWidthNarrow, 784px);
+$OpacityDisabled: var(--OpacityDisabled, 0.4);
+$SpacingLayout: var(--SpacingLayout, $SpacingXxl);
+$SpacingLayoutMaxWidthMargin: var(
+  --SpacingLayoutMaxWidthMargin,
+  $SpacingLayout
+);
+$BackdropFilter: var(--BackdropFilter, blur(5px) contrast(0.8));
+$AspectRatioWide: var(--AspectRatioWide, 16/9);
+$AspectRatioLandscape: var(--AspectRatioLandscape, 4/3);
+$AspectRatioSquare: var(--AspectRatioSquare, 1);
+$AspectRatio-portrait: var(--AspectRatio-portrait, 4/5);
+
+//////////////////////////////////// Radius ////////////////////////////////////
+$RadiusSmall: var(--RadiusSmall, 4px);
+$RadiusMedium: var(--RadiusMedium, 8px);
+$RadiusLarge: var(--RadiusLarge, 16px);
+$RadiusXl: var(--RadiusXl, 24px);
+$RadiusXxl: var(--RadiusXxl, 32px);
+
+//////////////////////////////////// Logo watermark ////////////////////////////////////
+$RadiusPill: var(--RadiusPill, 250px);
+$LogoSize: var(--LogoSize, $SpacingXl);
+$LogoWordmarkSpacing: var(--LogoWordmarkSpacing, 5px);
+$WordmarkSizeConjested: var(--WordmarkSizeConjested, 25px);
+$WordmarkSize: var(--WordmarkSize, calc(1rem * 1.875));

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -34,6 +34,10 @@
     background-color: $ColorPrimary20;
   }
 
+  &:after {
+    transition: none !important;
+  }
+
   &-primary:disabled {
     background-color: $ColorFeedbackError20;
     color: $ColorFeedbackError80;

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -5,7 +5,7 @@
   cursor: pointer;
   box-shadow: none;
   font-family: $PrimaryFont;
-  font-size: $BaseFontSize + 3;
+  font-size: $BaseFontSize + 5;
   font-weight: 700;
   line-height: 1.8rem;
   text-align: center;
@@ -16,20 +16,168 @@
   text-decoration: none;
   box-sizing: border-box;
   letter-spacing: 0.05rem;
+  padding: 0rem 3rem;
+  border-radius: 0.3rem;
+  color: $WhiteColor;
 
   &:disabled {
-    // opacity: 0.4;
     cursor: not-allowed;
     pointer-events: none;
+  }
+
+  &:focus {
+    text-decoration: none;
+    text-underline-position: under;
+  }
+
+  &:active {
+    background-color: $ColorPrimary20;
+  }
+
+  &-primary:disabled {
+    background-color: $ColorFeedbackError20;
+    color: $ColorFeedbackError80;
+  }
+
+  &-secondary:disabled {
+    border-color: $ColorSecondaryGrey80;
+    color: $ColorFeedbackError80;
+  }
+
+  &-tertiary:disabled {
+    color: $ColorFeedbackError80;
   }
 }
 
 .n-button-primary {
-  color: $PrimaryColor;
+  background-color: $ColorPrimary50;
+
+  &:hover:not([disabled]) {
+    background-color: $ColorPrimary60;
+  }
+
+  &:active:not([disabled]) {
+    color: $ColorPrimary30;
+  }
+
+  &-positive {
+    background-color: $ColorFeedbackSuccess20;
+    color: $ColorFeedbackSuccess80;
+
+    &:hover:not([disabled]) {
+      background-color: $ColorFeedbackSuccess50;
+      color: $ColorWhite;
+    }
+
+    &:active:not([disabled]) {
+      background-color: $ColorFeedbackSuccess80;
+      color: $ColorFeedbackSuccess20;
+    }
+  }
+
+  &-destructive {
+    background-color: $ColorFeedbackError20;
+    color: $ColorFeedbackError80;
+
+    &:hover:not([disabled]) {
+      background-color: $ColorFeedbackError50;
+      color: $ColorWhite;
+    }
+
+    &:active:not([disabled]) {
+      background-color: $ColorFeedbackError80;
+      color: $ColorFeedbackError20;
+    }
+  }
 }
 
 .n-button-secondary {
-  color: $SecondaryColor;
+  color: $ColorPrimary60;
+  background-color: #00000000;
+  border: 1px solid $ColorSecondaryGrey40;
+
+  &:hover:not([disabled]) {
+    border-color: $ColorPrimary60;
+  }
+
+  &:active:not([disabled]) {
+    border-color: $ColorPrimary60;
+    background-color: $ColorPrimary20;
+  }
+
+  &-positive {
+    background-color: #00000000;
+    color: $ColorFeedbackSuccess80;
+    border: 1px solid $ColorSecondaryGrey40;
+
+    &:hover:not([disabled]) {
+      background-color: #00000000;
+      border-color: $ColorFeedbackSuccess50;
+    }
+
+    &:active:not([disabled]) {
+      color: $ColorFeedbackSuccess80;
+      background-color: $ColorFeedbackSuccess20;
+    }
+  }
+
+  &-destructive {
+    background-color: #00000000;
+    border: 1px solid $ColorFeedbackError20;
+    color: $ColorFeedbackError80;
+
+    &:hover:not([disabled]) {
+      background-color: $ColorWhite;
+      border-color: $ColorFeedbackError50;
+    }
+
+    &:active:not([disabled]) {
+      background-color: $ColorFeedbackError20;
+      color: $ColorFeedbackError80;
+    }
+  }
+}
+
+.n-button-tertiary {
+  background: transparent;
+  border: none;
+  color: $ColorPrimary60;
+
+  &:hover:not([disabled]) {
+    background-color: $ColorPrimary20;
+  }
+
+  &:active:not([disabled]) {
+    background-color: $ColorPrimary30;
+  }
+
+  &-positive {
+    background-color: #00000000;
+    color: $ColorFeedbackSuccess80;
+
+    &:hover:not([disabled]) {
+      background-color: $ColorFeedbackSuccess20;
+    }
+
+    &:active:not([disabled]) {
+      background-color: $ColorFeedbackSuccess80;
+      color: $ColorFeedbackSuccess20;
+    }
+  }
+
+  &-destructive {
+    background-color: #00000000;
+    color: $ColorFeedbackError80;
+
+    &:hover:not([disabled]) {
+      background-color: $ColorFeedbackError20;
+    }
+
+    &:active:not([disabled]) {
+      background-color: $ColorFeedbackError80;
+      color: $ColorFeedbackError20;
+    }
+  }
 }
 
 .hover-state {
@@ -45,33 +193,6 @@
   transform: translate(-50%, -50%);
 }
 
-.n-flat-button {
-  padding: 0rem 3rem;
-  border-radius: 0.3rem;
-  color: $WhiteColor;
-
-  &:focus {
-    text-decoration: underline;
-    text-underline-position: under;
-  }
-}
-
-.n-flat-button-primary {
-  background-color: $PrimaryColor;
-
-  &:hover:not([disabled]) {
-    background-color: $PrimaryHoverColor;
-  }
-}
-
-.n-flat-button-secondary {
-  background-color: $SecondaryColor;
-
-  &:hover:not([disabled]) {
-    background-color: $SecondaryHoverColor;
-  }
-}
-
 .n-button-stroke {
   // padding: 0rem 4rem;
   padding: 0rem 3rem;
@@ -84,49 +205,27 @@
   }
 }
 
-.n-button-stroke-primary {
-  border: 0.1rem solid $PrimaryColor;
-  color: $PrimaryColor;
+// .n-button-stroke-primary {
+//   border: 0.1rem solid $PrimaryColor;
+//   color: $PrimaryColor;
 
-  // background-color: #B5FFE7;
-  &:hover:not([disabled]) {
-    background-color: #dfefe9;
-  }
-}
+//   // background-color: #B5FFE7;
+//   &:hover:not([disabled]) {
+//     background-color: #dfefe9;
+//   }
+// }
 
-.n-button-stroke-secondary {
-  border: 0.1rem solid $SecondaryColor;
-  color: $SecondaryColor;
+// .n-button-stroke-secondary {
+//   border: 0.1rem solid $SecondaryColor;
+//   color: $SecondaryColor;
 
-  &:hover:not([disabled]) {
-    background-color: $HoverEnabled;
-  }
-}
+//   &:hover:not([disabled]) {
+//     background-color: $HoverEnabled;
+//   }
+// }
 
-.n-button-link {
-  background: transparent;
-  border: none;
-  &.n-button-primary,
-  &.n-flat-button-primary {
-    color: $PrimaryColor;
-    &:hover:not([disabled]) {
-      color: $PrimaryHoverColor;
-      background-color: transparent;
-    }
-  }
-  &.n-button-secondary {
-    color: $SecondaryColor;
-    &:hover:not([disabled]) {
-      color: $SecondaryHoverColor;
-      background-color: transparent;
-    }
-  }
-  &:hover:not([disabled]) {
-    background-color: transparent;
-  }
-}
-.n-button-stroke:disabled,
-.n-flat-button:disabled,
+// .n-button-stroke:disabled,
+// .n-flat-button:disabled,
 .n-button-rounded:disabled {
   cursor: not-allowed;
   pointer-events: none;
@@ -134,28 +233,44 @@
 }
 
 .n-button-rounded {
-  border-radius: 2.4rem;
+  border-radius: 3.4rem;
   padding: 0rem 3.2rem;
 }
 
 .n-button-large {
-  padding: 1.3rem 2.4rem;
-  height: 4.8rem;
-  font-size: $BaseFontSize + 8;
+  padding: 1.6rem 2.4rem; // 1.6rem 0.6rem;
+  height: 5.4rem;
+  font-size: 18px;
   line-height: 2.5rem;
+  min-width: 5.4rem;
+
+  &_only_icon {
+    padding: 1.6rem 0.6rem !important;
+  }
 }
 
 .n-button-mid {
-  padding: 0.95rem 1.6rem;
-  height: 4rem;
-  font-size: $BaseFontSize + 5;
-  line-height: 2.1rem;
+  padding: 1.2rem 1.6rem; // 1.2rem 1.2rem;
+  height: 4.8rem;
+  font-size: 15px;
+  line-height: 2.5rem;
+  min-width: 4.8rem;
+
+  &_only_icon {
+    padding: 1.2rem 1.2rem !important;
+  }
 }
+
 .n-button-small {
-  padding: 0.55rem 1.2rem;
+  padding: 0.4rem 1.6rem; //0.4rem 0.4rem;
   height: 3rem;
   font-size: $BaseFontSize + 2;
   line-height: 1.9rem;
+  min-width: 3rem;
+
+  &_only_icon {
+    padding: 0.4rem 0.4rem !important;
+  }
 }
 
 .n-button-focused {
@@ -179,24 +294,36 @@
   justify-content: center;
 }
 
-.social-icon {
+.social-icon,
+.social-icon-right {
   display: flex;
   justify-content: center;
   align-items: center;
+}
+
+.icon-padding-left {
+  padding-left: $SpacingBase;
+}
+
+.icon-padding-right {
+  padding-right: $SpacingBase;
 }
 
 .n-icon-small {
   height: 2rem;
   font-size: 2rem;
 }
+
 .n-icon {
   height: 2.4rem;
   font-size: 2.4rem;
 }
+
 .n-icon-large {
   height: 3rem;
   font-size: 3rem;
 }
+
 .disable-click {
   pointer-events: none;
 }

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -245,8 +245,8 @@
 }
 
 .n-button-focused {
-  text-decoration: underline;
-  text-underline-position: under;
+  text-decoration: underline !important;
+  text-underline-position: under !important;
 }
 
 .n-button-content {
@@ -270,6 +270,10 @@
   display: flex;
   justify-content: center;
   align-items: center;
+}
+
+.social-icon-right {
+  margin-left: auto;
 }
 
 .icon-padding-left {
@@ -309,4 +313,8 @@
   justify-content: space-evenly;
   grid-gap: 1.6rem;
   padding: 1.6rem;
+}
+
+.n-button-full-width {
+  width: 100%;
 }

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -193,39 +193,6 @@
   transform: translate(-50%, -50%);
 }
 
-.n-button-stroke {
-  // padding: 0rem 4rem;
-  padding: 0rem 3rem;
-  border-radius: 0.3rem;
-  background: $WhiteColor;
-
-  &:focus {
-    text-decoration: underline;
-    text-underline-position: under;
-  }
-}
-
-// .n-button-stroke-primary {
-//   border: 0.1rem solid $PrimaryColor;
-//   color: $PrimaryColor;
-
-//   // background-color: #B5FFE7;
-//   &:hover:not([disabled]) {
-//     background-color: #dfefe9;
-//   }
-// }
-
-// .n-button-stroke-secondary {
-//   border: 0.1rem solid $SecondaryColor;
-//   color: $SecondaryColor;
-
-//   &:hover:not([disabled]) {
-//     background-color: $HoverEnabled;
-//   }
-// }
-
-// .n-button-stroke:disabled,
-// .n-flat-button:disabled,
 .n-button-rounded:disabled {
   cursor: not-allowed;
   pointer-events: none;

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 import Button from "./Button";
-import { SvgStore } from "../../assets/svg-components";
+import * as SvgArray from "../../assets/svg-components";
 export default {
   title: "Components/Button",
   component: Button,
@@ -15,7 +15,13 @@ export default {
     theme: {
       control: "select",
       description: "This property sets the theme of the button",
-      options: ["primary", "secondary"],
+      options: ["primary", "secondary", "tertiary"],
+    },
+    as: {
+      control: "select",
+      description:
+        "Whether the root element should be a `<div>` or `<span>` instead of a `<button>`",
+      options: ["div", "span"],
     },
     size: {
       control: "select",
@@ -44,9 +50,10 @@ export default {
       control: { type: "boolean" },
       description: "This property sets focus on the button.",
     },
-    link: {
-      control: { type: "boolean" },
-      description: "This property makes button look like link",
+    state: {
+      control: "select",
+      description: "Changes the button to custom state",
+      options: ["positive", "destructive", "default"],
     },
     showProgress: {
       control: { type: "boolean" },
@@ -63,7 +70,12 @@ export default {
       description: "This property sets name for the button.",
     },
     icon: {
-      description: "This property sets an icon for the button.",
+      description: "Displays icon on the left.",
+      options: SvgArray,
+    },
+    iconRight: {
+      description: "Displays icon on the right with.",
+      options: SvgArray,
     },
   },
 } as ComponentMeta<typeof Button>;
@@ -82,93 +94,142 @@ Default.args = {
 export const PrimaryAndOutline = () => (
   <div className="main-div">
     <div className="sb-display-grid">
-      <Button size="large">Button</Button>
-      <Button size="medium">Button</Button>
       <Button size="small">Button</Button>
+      <Button size="medium">Button</Button>
+      <Button size="lagge">Button</Button>
     </div>
     <div className="sb-display-grid">
-      <Button size="large" disabled>
+      <Button size="small" disabled>
         Button
       </Button>
       <Button size="medium" disabled>
         Button
       </Button>
-      <Button size="small" disabled>
+      <Button size="lagge" disabled>
         Button
       </Button>
     </div>
     <div className="sb-display-grid">
-      <Button size="large" stroke>
+      <Button size="small" stroke>
         Button
       </Button>
       <Button size="medium" stroke>
         Button
       </Button>
-      <Button size="small" stroke>
+      <Button size="lagge" stroke>
         Button
       </Button>
     </div>
     <div className="sb-display-grid">
-      <Button size="large" stroke disabled>
+      <Button size="small" stroke disabled>
         Button
       </Button>
       <Button size="medium" stroke disabled>
         Button
       </Button>
-      <Button size="small" stroke disabled>
+      <Button size="lagge" stroke disabled>
         Button
       </Button>
     </div>
   </div>
 );
 
-export const LinkButton = () => (
-  <div className="main-div">
-    <div className="sb-display-grid">
-      <Button size="large" link>
-        Button
-      </Button>
-      <Button size="medium" link>
-        Button
-      </Button>
-      <Button size="small" link>
-        Button
-      </Button>
-    </div>
-    <div className="sb-display-grid">
-      <Button theme="secondary" size="large" link>
-        Button
-      </Button>
-      <Button theme="secondary" size="medium" link>
-        Button
-      </Button>
-      <Button theme="secondary" size="small" link>
-        Button
-      </Button>
-    </div>
-  </div>
-);
+// export const LinkButton = () => (
+//   <div className="main-div">
+//     <div className="sb-display-grid">
+//       <Button size="large" link>
+//         Button
+//       </Button>
+//       <Button size="medium" link>
+//         Button
+//       </Button>
+//       <Button size="small" link>
+//         Button
+//       </Button>
+//     </div>
+//     <div className="sb-display-grid">
+//       <Button theme="secondary" size="large" link>
+//         Button
+//       </Button>
+//       <Button theme="secondary" size="medium" link>
+//         Button
+//       </Button>
+//       <Button theme="secondary" size="small" link>
+//         Button
+//       </Button>
+//     </div>
+//   </div>
+// );
 export const IconButton = () => (
   <div className="main-div">
     <div className="sb-display-grid">
-      <Button icon={SvgStore} size="small"></Button>
-      <Button icon={SvgStore} size="medium"></Button>
-      <Button icon={SvgStore} size="large"></Button>
+      <Button icon={SvgArray.SvgStore} size="small"></Button>
+      <Button icon={SvgArray.SvgStore} size="medium"></Button>
+      <Button icon={SvgArray.SvgStore} size="large"></Button>
     </div>
     <div className="sb-display-grid">
-      <Button icon={SvgStore} size="small" stroke></Button>
-      <Button icon={SvgStore} size="medium" stroke></Button>
-      <Button icon={SvgStore} size="large" stroke></Button>
+      <Button icon={SvgArray.SvgStore} size="small" stroke></Button>
+      <Button icon={SvgArray.SvgStore} size="medium" stroke></Button>
+      <Button icon={SvgArray.SvgStore} size="large" stroke></Button>
     </div>
     <div className="sb-display-grid">
-      <Button icon={SvgStore} size="small" disabled></Button>
-      <Button icon={SvgStore} size="medium" disabled></Button>
-      <Button icon={SvgStore} size="large" disabled></Button>
+      <Button icon={SvgArray.SvgStore} size="small" disabled></Button>
+      <Button icon={SvgArray.SvgStore} size="medium" disabled></Button>
+      <Button icon={SvgArray.SvgStore} size="large" disabled></Button>
     </div>
     <div className="sb-display-grid">
-      <Button icon={SvgStore} size="small" disabled stroke></Button>
-      <Button icon={SvgStore} size="medium" disabled stroke></Button>
-      <Button icon={SvgStore} size="large" disabled stroke></Button>
+      <Button icon={SvgArray.SvgStore} size="small" disabled stroke></Button>
+      <Button icon={SvgArray.SvgStore} size="medium" disabled stroke></Button>
+      <Button icon={SvgArray.SvgStore} size="large" disabled stroke></Button>
+    </div>
+  </div>
+);
+
+export const IconRightButton = () => (
+  <div className="main-div">
+    <div className="sb-display-grid">
+      <Button iconRight={SvgArray.SvgStore} size="small">
+        Button
+      </Button>
+      <Button iconRight={SvgArray.SvgStore} size="medium">
+        Button
+      </Button>
+      <Button iconRight={SvgArray.SvgStore} size="large">
+        Button
+      </Button>
+    </div>
+    <div className="sb-display-grid">
+      <Button iconRight={SvgArray.SvgStore} size="small" stroke>
+        Button
+      </Button>
+      <Button iconRight={SvgArray.SvgStore} size="medium" stroke>
+        Button
+      </Button>
+      <Button iconRight={SvgArray.SvgStore} size="large" stroke>
+        Button
+      </Button>
+    </div>
+    <div className="sb-display-grid">
+      <Button iconRight={SvgArray.SvgStore} size="small" disabled>
+        Button
+      </Button>
+      <Button iconRight={SvgArray.SvgStore} size="medium" disabled>
+        Button
+      </Button>
+      <Button iconRight={SvgArray.SvgStore} size="large" disabled>
+        Button
+      </Button>
+    </div>
+    <div className="sb-display-grid">
+      <Button iconRight={SvgArray.SvgStore} size="small" disabled stroke>
+        Button
+      </Button>
+      <Button iconRight={SvgArray.SvgStore} size="medium" disabled stroke>
+        Button
+      </Button>
+      <Button iconRight={SvgArray.SvgStore} size="large" disabled stroke>
+        Button
+      </Button>
     </div>
   </div>
 );

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -28,11 +28,6 @@ export default {
       description: "This property sets the size of the button",
       options: ["small", "medium", "large"],
     },
-    type: {
-      control: "select",
-      description: "This property sets the type of the button",
-      options: ["button", "submit", "reset"],
-    },
     rounded: {
       control: { type: "boolean" },
       description: "This property sets the border radius of the button",
@@ -58,6 +53,10 @@ export default {
     showProgress: {
       control: { type: "boolean" },
       description: "This property adds a loader on the button.",
+    },
+    fullWidth: {
+      control: { type: "boolean" },
+      description: "Whether the button takes full width or not",
     },
     id: {
       description: "This property sets a unique identifier for the button.",
@@ -183,7 +182,7 @@ export const IconButton = () => (
   </div>
 );
 
-export const IconRightButton = () => (
+export const ButtonWithIconLeft = () => (
   <div className="main-div">
     <div className="sb-display-grid">
       <Button theme="primary" size="small" icon={SvgArray.SvgStore}>
@@ -215,6 +214,127 @@ export const IconRightButton = () => (
         Button
       </Button>
       <Button theme="tertiary" size="large" icon={SvgArray.SvgStore}>
+        Button
+      </Button>
+    </div>
+  </div>
+);
+
+export const ButtonWithIconRight = () => (
+  <div className="main-div">
+    <div className="sb-display-grid">
+      <Button theme="primary" size="small" iconRight={SvgArray.SvgStore}>
+        Button
+      </Button>
+      <Button theme="primary" size="medium" iconRight={SvgArray.SvgStore}>
+        Button
+      </Button>
+      <Button theme="primary" size="large" iconRight={SvgArray.SvgStore}>
+        Button
+      </Button>
+    </div>
+    <div className="sb-display-grid">
+      <Button theme="secondary" size="small" iconRight={SvgArray.SvgStore}>
+        Button
+      </Button>
+      <Button theme="secondary" size="medium" iconRight={SvgArray.SvgStore}>
+        Button
+      </Button>
+      <Button theme="secondary" size="large" iconRight={SvgArray.SvgStore}>
+        Button
+      </Button>
+    </div>
+    <div className="sb-display-grid">
+      <Button theme="tertiary" size="small" iconRight={SvgArray.SvgStore}>
+        Button
+      </Button>
+      <Button theme="tertiary" size="medium" iconRight={SvgArray.SvgStore}>
+        Button
+      </Button>
+      <Button theme="tertiary" size="large" iconRight={SvgArray.SvgStore}>
+        Button
+      </Button>
+    </div>
+  </div>
+);
+
+export const ButtonWithBothIcon = () => (
+  <div className="main-div">
+    <div className="sb-display-grid">
+      <Button
+        theme="primary"
+        size="small"
+        icon={SvgArray.SvgStore}
+        iconRight={SvgArray.SvgArrowRight}
+      >
+        Button
+      </Button>
+      <Button
+        theme="primary"
+        size="medium"
+        icon={SvgArray.SvgStore}
+        iconRight={SvgArray.SvgArrowRight}
+      >
+        Button
+      </Button>
+      <Button
+        theme="primary"
+        size="large"
+        icon={SvgArray.SvgStore}
+        iconRight={SvgArray.SvgArrowRight}
+      >
+        Button
+      </Button>
+    </div>
+    <div className="sb-display-grid">
+      <Button
+        theme="secondary"
+        size="small"
+        icon={SvgArray.SvgStore}
+        iconRight={SvgArray.SvgArrowRight}
+      >
+        Button
+      </Button>
+      <Button
+        theme="secondary"
+        size="medium"
+        icon={SvgArray.SvgStore}
+        iconRight={SvgArray.SvgArrowRight}
+      >
+        Button
+      </Button>
+      <Button
+        theme="secondary"
+        size="large"
+        icon={SvgArray.SvgStore}
+        iconRight={SvgArray.SvgArrowRight}
+      >
+        Button
+      </Button>
+    </div>
+    <div className="sb-display-grid">
+      <Button
+        theme="tertiary"
+        size="small"
+        icon={SvgArray.SvgStore}
+        iconRight={SvgArray.SvgArrowRight}
+      >
+        Button
+      </Button>
+      <Button
+        theme="tertiary"
+        size="medium"
+        icon={SvgArray.SvgStore}
+        iconRight={SvgArray.SvgArrowRight}
+      >
+        Button
+      </Button>
+      <Button
+        theme="tertiary"
+        size="large"
+        icon={SvgArray.SvgStore}
+        iconRight={SvgArray.SvgArrowRight}
+      >
         Button
       </Button>
     </div>

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -59,10 +59,6 @@ export default {
       control: { type: "boolean" },
       description: "This property adds a loader on the button.",
     },
-    stroke: {
-      control: { type: "boolean" },
-      description: "This property removes the background color of the button.",
-    },
     id: {
       description: "This property sets a unique identifier for the button.",
     },
@@ -91,96 +87,98 @@ Default.args = {
   children: "Button",
 };
 
-export const PrimaryAndOutline = () => (
+export const AllThemes = () => (
   <div className="main-div">
     <div className="sb-display-grid">
-      <Button size="small">Button</Button>
-      <Button size="medium">Button</Button>
-      <Button size="lagge">Button</Button>
-    </div>
-    <div className="sb-display-grid">
-      <Button size="small" disabled>
+      <Button theme="primary" size="small">
         Button
       </Button>
-      <Button size="medium" disabled>
+      <Button theme="primary" size="medium">
         Button
       </Button>
-      <Button size="lagge" disabled>
+      <Button theme="primary" size="large">
         Button
       </Button>
     </div>
     <div className="sb-display-grid">
-      <Button size="small" stroke>
+      <Button theme="secondary" size="small">
         Button
       </Button>
-      <Button size="medium" stroke>
+      <Button theme="secondary" size="medium">
         Button
       </Button>
-      <Button size="lagge" stroke>
+      <Button theme="secondary" size="large">
         Button
       </Button>
     </div>
     <div className="sb-display-grid">
-      <Button size="small" stroke disabled>
+      <Button theme="tertiary" size="small">
         Button
       </Button>
-      <Button size="medium" stroke disabled>
+      <Button theme="tertiary" size="medium">
         Button
       </Button>
-      <Button size="lagge" stroke disabled>
+      <Button theme="tertiary" size="large">
         Button
       </Button>
     </div>
   </div>
 );
 
-// export const LinkButton = () => (
-//   <div className="main-div">
-//     <div className="sb-display-grid">
-//       <Button size="large" link>
-//         Button
-//       </Button>
-//       <Button size="medium" link>
-//         Button
-//       </Button>
-//       <Button size="small" link>
-//         Button
-//       </Button>
-//     </div>
-//     <div className="sb-display-grid">
-//       <Button theme="secondary" size="large" link>
-//         Button
-//       </Button>
-//       <Button theme="secondary" size="medium" link>
-//         Button
-//       </Button>
-//       <Button theme="secondary" size="small" link>
-//         Button
-//       </Button>
-//     </div>
-//   </div>
-// );
+export const AllDisbledThemes = () => (
+  <div className="main-div">
+    <div className="sb-display-grid">
+      <Button theme="primary" size="small" disabled>
+        Button
+      </Button>
+      <Button theme="primary" size="medium" disabled>
+        Button
+      </Button>
+      <Button theme="primary" size="large" disabled>
+        Button
+      </Button>
+    </div>
+    <div className="sb-display-grid">
+      <Button theme="secondary" size="small" disabled>
+        Button
+      </Button>
+      <Button theme="secondary" size="medium" disabled>
+        Button
+      </Button>
+      <Button theme="secondary" size="large" disabled>
+        Button
+      </Button>
+    </div>
+    <div className="sb-display-grid">
+      <Button theme="tertiary" size="small" disabled>
+        Button
+      </Button>
+      <Button theme="tertiary" size="medium" disabled>
+        Button
+      </Button>
+      <Button theme="tertiary" size="large" disabled>
+        Button
+      </Button>
+    </div>
+  </div>
+);
+
 export const IconButton = () => (
   <div className="main-div">
     <div className="sb-display-grid">
-      <Button icon={SvgArray.SvgStore} size="small"></Button>
-      <Button icon={SvgArray.SvgStore} size="medium"></Button>
-      <Button icon={SvgArray.SvgStore} size="large"></Button>
+      <Button theme="primary" size="small" icon={SvgArray.SvgStore}></Button>
+      <Button theme="primary" size="medium" icon={SvgArray.SvgStore}></Button>
+      <Button theme="primary" size="large" icon={SvgArray.SvgStore}></Button>
     </div>
     <div className="sb-display-grid">
-      <Button icon={SvgArray.SvgStore} size="small" stroke></Button>
-      <Button icon={SvgArray.SvgStore} size="medium" stroke></Button>
-      <Button icon={SvgArray.SvgStore} size="large" stroke></Button>
+      <Button theme="secondary" size="small" icon={SvgArray.SvgStore}></Button>
+      <Button theme="secondary" size="medium" icon={SvgArray.SvgStore}></Button>
+      <Button theme="secondary" size="large" icon={SvgArray.SvgStore}></Button>
     </div>
     <div className="sb-display-grid">
-      <Button icon={SvgArray.SvgStore} size="small" disabled></Button>
-      <Button icon={SvgArray.SvgStore} size="medium" disabled></Button>
-      <Button icon={SvgArray.SvgStore} size="large" disabled></Button>
-    </div>
-    <div className="sb-display-grid">
-      <Button icon={SvgArray.SvgStore} size="small" disabled stroke></Button>
-      <Button icon={SvgArray.SvgStore} size="medium" disabled stroke></Button>
-      <Button icon={SvgArray.SvgStore} size="large" disabled stroke></Button>
+      <Button theme="tertiary" size="small" icon={SvgArray.SvgStore}></Button>
+      <Button theme="tertiary" size="medium" icon={SvgArray.SvgStore}></Button>
+      <Button theme="tertiary" size="large" icon={SvgArray.SvgStore}></Button>
     </div>
   </div>
 );
@@ -188,46 +186,111 @@ export const IconButton = () => (
 export const IconRightButton = () => (
   <div className="main-div">
     <div className="sb-display-grid">
-      <Button iconRight={SvgArray.SvgStore} size="small">
+      <Button theme="primary" size="small" icon={SvgArray.SvgStore}>
         Button
       </Button>
-      <Button iconRight={SvgArray.SvgStore} size="medium">
+      <Button theme="primary" size="medium" icon={SvgArray.SvgStore}>
         Button
       </Button>
-      <Button iconRight={SvgArray.SvgStore} size="large">
-        Button
-      </Button>
-    </div>
-    <div className="sb-display-grid">
-      <Button iconRight={SvgArray.SvgStore} size="small" stroke>
-        Button
-      </Button>
-      <Button iconRight={SvgArray.SvgStore} size="medium" stroke>
-        Button
-      </Button>
-      <Button iconRight={SvgArray.SvgStore} size="large" stroke>
+      <Button theme="primary" size="large" icon={SvgArray.SvgStore}>
         Button
       </Button>
     </div>
     <div className="sb-display-grid">
-      <Button iconRight={SvgArray.SvgStore} size="small" disabled>
+      <Button theme="secondary" size="small" icon={SvgArray.SvgStore}>
         Button
       </Button>
-      <Button iconRight={SvgArray.SvgStore} size="medium" disabled>
+      <Button theme="secondary" size="medium" icon={SvgArray.SvgStore}>
         Button
       </Button>
-      <Button iconRight={SvgArray.SvgStore} size="large" disabled>
+      <Button theme="secondary" size="large" icon={SvgArray.SvgStore}>
         Button
       </Button>
     </div>
     <div className="sb-display-grid">
-      <Button iconRight={SvgArray.SvgStore} size="small" disabled stroke>
+      <Button theme="tertiary" size="small" icon={SvgArray.SvgStore}>
         Button
       </Button>
-      <Button iconRight={SvgArray.SvgStore} size="medium" disabled stroke>
+      <Button theme="tertiary" size="medium" icon={SvgArray.SvgStore}>
         Button
       </Button>
-      <Button iconRight={SvgArray.SvgStore} size="large" disabled stroke>
+      <Button theme="tertiary" size="large" icon={SvgArray.SvgStore}>
+        Button
+      </Button>
+    </div>
+  </div>
+);
+
+export const AllThemesWithPositiveState = () => (
+  <div className="main-div">
+    <div className="sb-display-grid">
+      <Button theme="primary" size="small" state="positive">
+        Button
+      </Button>
+      <Button theme="primary" size="medium" state="positive">
+        Button
+      </Button>
+      <Button theme="primary" size="large" state="positive">
+        Button
+      </Button>
+    </div>
+    <div className="sb-display-grid">
+      <Button theme="secondary" size="small" state="positive">
+        Button
+      </Button>
+      <Button theme="secondary" size="medium" state="positive">
+        Button
+      </Button>
+      <Button theme="secondary" size="large" state="positive">
+        Button
+      </Button>
+    </div>
+    <div className="sb-display-grid">
+      <Button theme="tertiary" size="small" state="positive">
+        Button
+      </Button>
+      <Button theme="tertiary" size="medium" state="positive">
+        Button
+      </Button>
+      <Button theme="tertiary" size="large" state="positive">
+        Button
+      </Button>
+    </div>
+  </div>
+);
+
+export const AllThemesWithDestructiveState = () => (
+  <div className="main-div">
+    <div className="sb-display-grid">
+      <Button theme="primary" size="small" state="destructive">
+        Button
+      </Button>
+      <Button theme="primary" size="medium" state="destructive">
+        Button
+      </Button>
+      <Button theme="primary" size="large" state="destructive">
+        Button
+      </Button>
+    </div>
+    <div className="sb-display-grid">
+      <Button theme="secondary" size="small" state="destructive">
+        Button
+      </Button>
+      <Button theme="secondary" size="medium" state="destructive">
+        Button
+      </Button>
+      <Button theme="secondary" size="large" state="destructive">
+        Button
+      </Button>
+    </div>
+    <div className="sb-display-grid">
+      <Button theme="tertiary" size="small" state="destructive">
+        Button
+      </Button>
+      <Button theme="tertiary" size="medium" state="destructive">
+        Button
+      </Button>
+      <Button theme="tertiary" size="large" state="destructive">
         Button
       </Button>
     </div>

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render } from "@testing-library/react";
-
+import * as SvgArray from "../../assets/svg-components";
 import Button from "./Button";
 
 describe("Button", () => {
@@ -36,6 +36,42 @@ describe("Button", () => {
     );
     expect(container.getElementsByClassName("n-button-primary").length).toBe(1);
   });
+  test("renders the Button component with props - secondary, medium, href, className", () => {
+    const { container } = render(
+      <Button
+        theme="secondary"
+        size="medium"
+        href="http://example.com"
+        className="test-class"
+        onClick={() => {}}
+        id="btn"
+        name="btn"
+      >
+        Submit
+      </Button>
+    );
+    expect(container.getElementsByClassName("n-button-secondary").length).toBe(
+      1
+    );
+  });
+  test("renders the Button component with props - tertiary, medium, href, className", () => {
+    const { container } = render(
+      <Button
+        theme="tertiary"
+        size="medium"
+        href="http://example.com"
+        className="test-class"
+        onClick={() => {}}
+        id="btn"
+        name="btn"
+      >
+        Submit
+      </Button>
+    );
+    expect(container.getElementsByClassName("n-button-tertiary").length).toBe(
+      1
+    );
+  });
   test("renders the Button component with props - Secondary, small, className", () => {
     const { container } = render(
       <Button
@@ -69,5 +105,189 @@ describe("Button", () => {
       </Button>
     );
     expect(container.getElementsByClassName("n-button").length).toBe(1);
+  });
+  test("renders the Button component with props - Primary, href, className, state ", () => {
+    const { container } = render(
+      <Button
+        theme="primary"
+        size="small"
+        href="http://example.com"
+        className="test-class"
+        onClick={() => {}}
+        id="btn"
+        name="btn"
+        state="positive"
+      >
+        Submit
+      </Button>
+    );
+    expect(
+      container.getElementsByClassName("n-button-primary-positive").length
+    ).toBe(1);
+  });
+  test("renders the Button component with props - secondary, href, className, state ", () => {
+    const { container } = render(
+      <Button
+        theme="secondary"
+        size="small"
+        href="http://example.com"
+        className="test-class"
+        onClick={() => {}}
+        id="btn"
+        name="btn"
+        state="positive"
+      >
+        Submit
+      </Button>
+    );
+    expect(
+      container.getElementsByClassName("n-button-secondary-positive").length
+    ).toBe(1);
+  });
+  test("renders the Button component with props - tertiary, href, className, state ", () => {
+    const { container } = render(
+      <Button
+        theme="tertiary"
+        size="small"
+        href="http://example.com"
+        className="test-class"
+        onClick={() => {}}
+        id="btn"
+        name="btn"
+        state="positive"
+      >
+        Submit
+      </Button>
+    );
+    expect(
+      container.getElementsByClassName("n-button-tertiary-positive").length
+    ).toBe(1);
+  });
+  test("renders the Button component with props - primary, href, className, state ", () => {
+    const { container } = render(
+      <Button
+        theme="primary"
+        size="small"
+        href="http://example.com"
+        className="test-class"
+        onClick={() => {}}
+        id="btn"
+        name="btn"
+        state="destructive"
+      >
+        Submit
+      </Button>
+    );
+    expect(
+      container.getElementsByClassName("n-button-primary-destructive").length
+    ).toBe(1);
+  });
+  test("renders the Button component with props - secondary, href, className, state ", () => {
+    const { container } = render(
+      <Button
+        theme="secondary"
+        size="small"
+        href="http://example.com"
+        className="test-class"
+        onClick={() => {}}
+        id="btn"
+        name="btn"
+        state="destructive"
+      >
+        Submit
+      </Button>
+    );
+    expect(
+      container.getElementsByClassName("n-button-secondary-destructive").length
+    ).toBe(1);
+  });
+  test("renders the Button component with props - tertiary, href, className, state ", () => {
+    const { container } = render(
+      <Button
+        theme="tertiary"
+        size="small"
+        href="http://example.com"
+        className="test-class"
+        onClick={() => {}}
+        id="btn"
+        name="btn"
+        state="destructive"
+      >
+        Submit
+      </Button>
+    );
+    expect(
+      container.getElementsByClassName("n-button-tertiary-destructive").length
+    ).toBe(1);
+  });
+  test("renders the Button component with props - tertiary, className, fullWidth ", () => {
+    const { container } = render(
+      <Button
+        theme="tertiary"
+        size="small"
+        className="test-class"
+        onClick={() => {}}
+        id="btn"
+        name="btn"
+        fullWidth={true}
+      >
+        Submit
+      </Button>
+    );
+    expect(container.getElementsByClassName("n-button-full-width").length).toBe(
+      1
+    );
+  });
+  test("renders the Button component with props - tertiary, className, focused ", () => {
+    const { container } = render(
+      <Button
+        theme="tertiary"
+        size="small"
+        className="test-class"
+        onClick={() => {}}
+        id="btn"
+        name="btn"
+        focused={true}
+      >
+        Submit
+      </Button>
+    );
+    expect(container.getElementsByClassName("n-button-focused ").length).toBe(
+      1
+    );
+  });
+  test("renders the Button component with props - tertiary, className, icon ", () => {
+    const { container } = render(
+      <Button
+        theme="tertiary"
+        size="small"
+        className="test-class"
+        onClick={() => {}}
+        id="btn"
+        name="btn"
+        icon={SvgArray.Svg124}
+      >
+        Submit
+      </Button>
+    );
+    expect(container.getElementsByClassName("social-icon").length).toBe(1);
+  });
+  test("renders the Button component with props - tertiary, className, iconRight ", () => {
+    const { container } = render(
+      <Button
+        theme="tertiary"
+        size="small"
+        className="test-class"
+        onClick={() => {}}
+        id="btn"
+        name="btn"
+        iconRight={SvgArray.Svg124}
+      >
+        Submit
+      </Button>
+    );
+    expect(container.getElementsByClassName("social-icon-right").length).toBe(
+      1
+    );
   });
 });

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -20,14 +20,13 @@ describe("Button", () => {
     );
     expect(getByText("Submit")).toBeInTheDocument();
   });
-  test("renders the Button component with props - Primary, medium, href, className, stroke", () => {
+  test("renders the Button component with props - Primary, medium, href, className", () => {
     const { container } = render(
       <Button
         theme="primary"
         size="medium"
         href="http://example.com"
         className="test-class"
-        stroke={true}
         onClick={() => {}}
         id="btn"
         name="btn"
@@ -37,14 +36,13 @@ describe("Button", () => {
     );
     expect(container.getElementsByClassName("n-button-primary").length).toBe(1);
   });
-  test("renders the Button component with props - Secondary, stroke, small, className", () => {
+  test("renders the Button component with props - Secondary, small, className", () => {
     const { container } = render(
       <Button
         theme="secondary"
         size="small"
         href="http://example.com"
         className="test-class"
-        stroke={true}
         onClick={() => {}}
         id="btn"
         name="btn"
@@ -70,6 +68,6 @@ describe("Button", () => {
         Submit
       </Button>
     );
-    expect(container.getElementsByClassName("n-flat-button").length).toBe(1);
+    expect(container.getElementsByClassName("n-button").length).toBe(1);
   });
 });

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import loaderWhite from "./../../assets/loader-white.gif";
 import classnames from "classnames";
 import "./Button.scss";
-// import '../../base/base.scss';
 export interface ButtonProps {
   href?: string;
   type?: "button" | "submit" | "reset";
@@ -14,7 +13,6 @@ export interface ButtonProps {
   size?: string;
   focused?: boolean;
   showProgress?: boolean;
-  stroke?: boolean;
   children: React.ReactNode;
   onClick?: React.MouseEventHandler<HTMLButtonElement | HTMLAnchorElement>;
   className?: string;
@@ -51,14 +49,6 @@ const Button = (props: ButtonProps) => {
       "n-button-small_only_icon": !props.children,
       "n-button-focused": props.focused,
       "n-button-disable": props.showProgress,
-      "n-button-stroke n-button-stroke-primary":
-        props.stroke && props.theme === "primary",
-      "n-button-stroke n-button-stroke-secondary":
-        props.stroke && props.theme === "secondary",
-      "n-flat-button n-flat-button-primary":
-        !props.stroke && props.theme === "primary",
-      "n-flat-button n-flat-button-secondary":
-        !props.stroke && props.theme === "secondary",
     });
   const generateAttributes = () => {
     if (props.href) {
@@ -66,7 +56,6 @@ const Button = (props: ButtonProps) => {
         rounded,
         theme,
         as,
-        stroke,
         size,
         focused,
         showProgress,
@@ -83,7 +72,6 @@ const Button = (props: ButtonProps) => {
         rounded,
         theme,
         as,
-        stroke,
         size,
         href,
         focused,
@@ -191,7 +179,6 @@ Button.defaultProps = {
   size: "medium",
   focused: false,
   showProgress: false,
-  stroke: null,
   children: null,
   onClick: null,
   className: null,

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -8,8 +8,9 @@ export interface ButtonProps {
   type?: "button" | "submit" | "reset";
   disabled?: boolean;
   rounded?: boolean;
-  link?: boolean;
+  state?: "positive" | "destructive" | "default";
   theme?: string;
+  as?: "div" | "span" | "default";
   size?: string;
   focused?: boolean;
   showProgress?: boolean;
@@ -19,6 +20,7 @@ export interface ButtonProps {
   className?: string;
   id?: string;
   icon?: React.ReactNode;
+  iconRight?: React.ReactNode;
   name?: string;
   style?: React.CSSProperties;
 }
@@ -27,10 +29,26 @@ const Button = (props: ButtonProps) => {
     classnames({
       "n-button-rounded": props.rounded,
       "n-button-primary": props.theme === "primary",
+      "n-button-primary-positive":
+        props.theme === "primary" && props.state === "positive",
+      "n-button-primary-destructive":
+        props.theme === "primary" && props.state === "destructive",
       "n-button-secondary": props.theme === "secondary",
+      "n-button-secondary-positive":
+        props.theme === "secondary" && props.state === "positive",
+      "n-button-secondary-destructive":
+        props.theme === "secondary" && props.state === "destructive",
+      "n-button-tertiary": props.theme === "tertiary",
+      "n-button-tertiary-positive":
+        props.theme === "tertiary" && props.state === "positive",
+      "n-button-tertiary-destructive":
+        props.theme === "tertiary" && props.state === "destructive",
       "n-button-large": props.size === "large",
+      "n-button-large_only_icon": !props.children,
       "n-button-mid": props.size === "medium",
+      "n-button-mid_only_icon": !props.children,
       "n-button-small": props.size === "small",
+      "n-button-small_only_icon": !props.children,
       "n-button-focused": props.focused,
       "n-button-disable": props.showProgress,
       "n-button-stroke n-button-stroke-primary":
@@ -41,13 +59,13 @@ const Button = (props: ButtonProps) => {
         !props.stroke && props.theme === "primary",
       "n-flat-button n-flat-button-secondary":
         !props.stroke && props.theme === "secondary",
-      "n-button-link": props.link,
     });
   const generateAttributes = () => {
     if (props.href) {
       const {
         rounded,
         theme,
+        as,
         stroke,
         size,
         focused,
@@ -56,6 +74,7 @@ const Button = (props: ButtonProps) => {
         className,
         children,
         icon,
+        iconRight,
         ...rest
       } = props;
       return { ...rest };
@@ -63,6 +82,7 @@ const Button = (props: ButtonProps) => {
       const {
         rounded,
         theme,
+        as,
         stroke,
         size,
         href,
@@ -71,6 +91,7 @@ const Button = (props: ButtonProps) => {
         className,
         children,
         icon,
+        iconRight,
         ...rest
       } = props;
       return { ...rest };
@@ -87,6 +108,24 @@ const Button = (props: ButtonProps) => {
     >
       <ButtonContent {...props} />
     </a>
+  ) : props.as == "div" ? (
+    <div
+      className={`n-button ripple ${generateClasses()} ${
+        props.className && props.className
+      }`}
+      {...generateAttributes} //{...generateAttributes()}
+    >
+      <ButtonContent {...props} />
+    </div>
+  ) : props.as == "span" ? (
+    <span
+      className={`n-button ripple ${generateClasses()} ${
+        props.className && props.className
+      }`}
+      {...generateAttributes()}
+    >
+      <ButtonContent {...props} />
+    </span>
   ) : (
     <button
       className={`n-button ripple ${generateClasses()} ${
@@ -101,26 +140,40 @@ const Button = (props: ButtonProps) => {
 
 const ButtonContent = (props: ButtonProps) => {
   const Icon = props.icon as React.ElementType;
+  const IconRight = props.iconRight as React.ElementType;
   return (
     <div className="n-button-content">
-      {!props.showProgress && props.icon && (
+      {props.icon && (props.children || !props.showProgress) && (
         <div className="social-icon">
           <Icon
             className={classnames({
               "n-icon-small": props.size === "small",
               "n-icon": props.size === "medium",
               "n-icon-large": props.size === "large",
+              "icon-padding-right": props.children,
             })}
           />
         </div>
       )}
-      {!props.showProgress && props.children}
+      {props.children}
       {props.showProgress && (
         <div className="n-btn-spin">
           <img
             className="n-btn-spinner"
             style={{ width: "50px" }}
             src={loaderWhite}
+          />
+        </div>
+      )}
+      {!props.showProgress && props.children && props.iconRight && (
+        <div className="social-icon-right">
+          <IconRight
+            className={classnames({
+              "n-icon-small": props.size === "small",
+              "n-icon": props.size === "medium",
+              "n-icon-large": props.size === "large",
+              "icon-padding-left": props.children,
+            })}
           />
         </div>
       )}
@@ -132,8 +185,9 @@ Button.defaultProps = {
   href: null,
   type: "button",
   disabled: false,
-  rounded: false,
+  rounded: true,
   theme: "primary",
+  as: null,
   size: "medium",
   focused: false,
   showProgress: false,

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -4,7 +4,6 @@ import classnames from "classnames";
 import "./Button.scss";
 export interface ButtonProps {
   href?: string;
-  type?: "button" | "submit" | "reset";
   disabled?: boolean;
   rounded?: boolean;
   state?: "positive" | "destructive" | "default";
@@ -13,6 +12,7 @@ export interface ButtonProps {
   size?: string;
   focused?: boolean;
   showProgress?: boolean;
+  fullWidth?: boolean;
   children: React.ReactNode;
   onClick?: React.MouseEventHandler<HTMLButtonElement | HTMLAnchorElement>;
   className?: string;
@@ -49,6 +49,7 @@ const Button = (props: ButtonProps) => {
       "n-button-small_only_icon": !props.children,
       "n-button-focused": props.focused,
       "n-button-disable": props.showProgress,
+      "n-button-full-width": props.fullWidth,
     });
   const generateAttributes = () => {
     if (props.href) {
@@ -59,6 +60,7 @@ const Button = (props: ButtonProps) => {
         size,
         focused,
         showProgress,
+        fullWidth,
         onClick,
         className,
         children,
@@ -76,6 +78,7 @@ const Button = (props: ButtonProps) => {
         href,
         focused,
         showProgress,
+        fullWidth,
         className,
         children,
         icon,
@@ -171,7 +174,6 @@ const ButtonContent = (props: ButtonProps) => {
 
 Button.defaultProps = {
   href: null,
-  type: "button",
   disabled: false,
   rounded: true,
   theme: "primary",
@@ -179,6 +181,7 @@ Button.defaultProps = {
   size: "medium",
   focused: false,
   showProgress: false,
+  fullWidth: false,
   children: null,
   onClick: null,
   className: null,

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -102,7 +102,6 @@ const Dialog = (props: DialogProps) => {
                     <Button
                       theme={`${theme || "primary"}`}
                       rounded={false}
-                      stroke
                       className="nitrozen-dialog-footer-button-margin"
                       onClick={handlePositiveButtonClick}
                     >


### PR DESCRIPTION
### Props that are removed and not supported anymore

* stroke ( JDS compliant design has a different theme (name as ‘secondary’) view for the same)
* link ( JDS compliant design has a different theme (name as ‘tertiary’) view for the same)

### New props added for JDS compliant changes

* theme ( add a new theme name as ‘tertiary’ ) string
* state ("positive" | "destructive" | "default" )
* as ( Whether the root element should be a `<div>` or` <span>` instead of a `<button>` ) ("div" | "span" | "default" )
* iconRight ( Optional ) ReactNode
* fullWidth (Optional) Whether the button takes full width or not

### [Ticket](https://gofynd.atlassian.net/browse/CACL-29)


### Stories
<img width="654" alt="Screenshot 2023-01-13 at 12 25 08 PM" src="https://user-images.githubusercontent.com/122079416/212271631-8d5d57ef-4efb-4130-9348-444a6c976798.png">
<img width="654" alt="Screenshot 2023-01-13 at 12 24 28 PM" src="https://user-images.githubusercontent.com/122079416/212271634-c63d92cc-e2c2-4d05-bef8-939c43eed038.png">
<img width="653" alt="Screenshot 2023-01-13 at 12 25 41 PM" src="https://user-images.githubusercontent.com/122079416/212271627-6b4d5d82-0c6b-4ba0-b0ef-b7b5e0d1e134.png">
<img width="640" alt="Screenshot 2023-01-13 at 12 25 25 PM" src="https://user-images.githubusercontent.com/122079416/212271610-2bd4f282-4e05-423a-aa0f-695032cb9b85.png">
<img width="655" alt="Screenshot 2023-01-13 at 12 25 33 PM" src="https://user-images.githubusercontent.com/122079416/212271621-8a413752-b8a6-405e-80c6-85c1ce61eca9.png">

