### PR TITLE
fix: fixing pagination onchange with updated state values

### DIFF
--- a/src/components/Pagination/Pagination.test.tsx
+++ b/src/components/Pagination/Pagination.test.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { render, fireEvent } from "@testing-library/react";
-
 import Pagination, { ModeEnum } from "./Pagination";
 
 describe("Pagination", () => {
@@ -135,5 +134,111 @@ describe("Pagination", () => {
     fireEvent.click(dropdown);
 
     expect(dropdown.getAttribute("data-value")).toBe("20");
+  });
+
+  test("onchange should not have been called on initial render", () => {
+    const testProps = {
+      id: "1",
+      name: "Pages",
+      value: {
+        limit: 10,
+        total: 100,
+        current: 2,
+        prevPage: "",
+        nextPage: "",
+        currentPage: "",
+        currentTotal: 100,
+      },
+      pageSizeOptions: [10, 20],
+      onChange: jest.fn(),
+      onPreviousClick: (event: any) => {},
+      onNextClick: (event: any) => {},
+    };
+
+    render(<Pagination {...testProps} />);
+
+    expect(testProps?.onChange).toBeCalledTimes(0);
+  });
+
+  test("onchange should have been called on next click", () => {
+    const testProps = {
+      id: "1",
+      name: "Pages",
+      value: {
+        limit: 10,
+        total: 100,
+        current: 2,
+        prevPage: "",
+        nextPage: "",
+        currentPage: "",
+        currentTotal: 100,
+      },
+      pageSizeOptions: [10, 20],
+      onChange: jest.fn(),
+      onPreviousClick: (event: any) => {},
+      onNextClick: (event: any) => {},
+    };
+
+    const { getByTestId } = render(<Pagination {...testProps} />);
+
+    const nextBtn = getByTestId("btnNext");
+    fireEvent.click(nextBtn);
+
+    expect(testProps?.onChange).toBeCalledTimes(1);
+  });
+
+  test("onchange should have been called on prev click", () => {
+    const testProps = {
+      id: "1",
+      name: "Pages",
+      value: {
+        limit: 10,
+        total: 100,
+        current: 2,
+        prevPage: "",
+        nextPage: "",
+        currentPage: "",
+        currentTotal: 100,
+      },
+      pageSizeOptions: [10, 20],
+      onChange: jest.fn(),
+      onPreviousClick: (event: any) => {},
+      onNextClick: (event: any) => {},
+    };
+
+    const { getByTestId } = render(<Pagination {...testProps} />);
+
+    const prevBtn = getByTestId("btnPrevious");
+    fireEvent.click(prevBtn);
+
+    expect(testProps?.onChange).toBeCalledTimes(1);
+  });
+
+  test("onchange should have been called on changing pageSize", () => {
+    const testProps = {
+      id: "1",
+      name: "Pages",
+      value: {
+        limit: 10,
+        total: 100,
+        current: 2,
+        prevPage: "",
+        nextPage: "",
+        currentPage: "",
+        currentTotal: 100,
+      },
+      pageSizeOptions: [10, 20],
+      onChange: jest.fn(),
+      onPreviousClick: (event: any) => {},
+      onNextClick: (event: any) => {},
+    };
+
+    const screen = render(<Pagination {...testProps} />);
+
+    const dropdown =
+      screen.container.getElementsByClassName("nitrozen-option")[1];
+    fireEvent.click(dropdown);
+
+    expect(testProps?.onChange).toBeCalledTimes(1);
   });
 });

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import NitrozenId from "../../utils/uuids";
 import Dropdown from "../Dropdown";
 import "./Pagination.scss";
@@ -48,9 +48,20 @@ const Pagination = (props: PaginationProps) => {
   const [selectedPageSize, setSelectedPageSize] = useState<any>(
     pageSizeOptions && pageSizeOptions.length > 0 ? pageSizeOptions[0] : 10
   );
+  const isFirstRender = useRef<boolean>(true);
+
   useEffect(() => {
     setDefaults();
   }, []);
+
+  useEffect(() => {
+    if (isFirstRender?.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    change();
+  }, [value]);
+
   function setDefaults() {
     if (!value.current) {
       setValue({ ...value, current: 1 });
@@ -67,7 +78,6 @@ const Pagination = (props: PaginationProps) => {
       if (!value.prevPage) return;
       setValue({ ...value, nextPage: "", currentPage: value.prevPage });
     }
-    change();
     onPreviousClick?.();
   }
   function next() {
@@ -88,7 +98,6 @@ const Pagination = (props: PaginationProps) => {
       if (!value.nextPage) return;
       setValue({ ...value, prevPage: "", currentPage: value.nextPage });
     }
-    change();
     onNextClick?.();
   }
   function pageSizeChange(size: number) {
@@ -105,7 +114,6 @@ const Pagination = (props: PaginationProps) => {
       setValue({ ...value, current: 1, limit: size });
     }
     setSelectedPageSize(size);
-    change();
   }
   function change() {
     onChange?.(value);


### PR DESCRIPTION
Issue :- The state passed in the onChange of the Pagination Component was the previous state. To make sure the onChange runs only when the state has been updated I have made these changes. (Done)

Snapshot of passing all the test cases

<img width="920" alt="Screenshot 2023-01-30 at 11 49 01 AM" src="https://user-images.githubusercontent.com/123541897/215402899-ec219a97-747d-42b9-b030-85ae95b21af4.png">
