### PR TITLE
refactor(chips): changes in default props and classnames

### DIFF
--- a/src/components/Chip/Chip.scss
+++ b/src/components/Chip/Chip.scss
@@ -1,6 +1,6 @@
 @import "./../../base/base.scss";
 
-.nitrozen-chip {
+.n-chip {
   background-color: $WhiteColor;
   @include d-flex-center;
   padding: 0.8rem;
@@ -8,7 +8,7 @@
   border-radius: 0.4rem;
   border: 0.1rem solid $ColorPrimaryGrey60;
   color: $TypographyPrimaryColor;
-  font-size: $BaseFontSize + 6;
+  font-size: 1.6rem;
   vertical-align: middle;
   white-space: nowrap;
   font-family: $PrimaryFont;
@@ -16,14 +16,14 @@
   box-sizing: border-box;
   user-select: none;
 
-  .chiptext {
+  .n-chiptext {
     word-break: break-all;
     text-overflow: ellipsis;
     overflow: hidden;
   }
 
-  .label {
-    font-size: $BaseFontSize + 6;
+  .n-chip-label {
+    font-size: 1.6rem;
     letter-spacing: -0.005em;
     color: $ColorPrimaryGrey80;
   }
@@ -31,19 +31,23 @@
   &:active {
     background-color: $GreyColor;
   }
+
   &:focus {
     border: 0.4rem solid $ActiveFieldBorder;
   }
+
   &:hover {
     // box-shadow: 0rem 0rem 0.5rem $Whisper;
     color: $ColorBlack;
   }
-  &.nitrozen-disabled {
+
+  &.n-disabled {
     cursor: default;
     background: $WhiteColor;
     color: $TypographyPrimaryColor;
     opacity: $DisabledOpacity;
     pointer-events: none;
+
     &:hover {
       box-shadow: none;
     }
@@ -53,18 +57,25 @@
       filter: saturate(65%);
     }
   }
-  &.nitrozen-chip-secondary {
+
+  &.n-chip-secondary {
     color: $PrimaryColor;
     border-color: $PrimaryColor;
     font-weight: 700;
   }
+
   &.rounded {
     border-radius: 3.9rem;
   }
-  .nitrozen-icon {
+
+  .n-icon {
     @include d-flex-center;
     margin-left: 0.4rem;
   }
+}
+
+.n-label-chip-text {
+  color: $ColorBlack;
 }
 
 //DEMO

--- a/src/components/Chip/Chip.stories.tsx
+++ b/src/components/Chip/Chip.stories.tsx
@@ -6,6 +6,7 @@ import {
   SvgDelete,
   SvgColorLens,
 } from "../../assets/svg-components";
+import * as SvgArray from "../../assets/svg-components";
 
 export default {
   title: "Components/Chip",
@@ -27,6 +28,7 @@ export default {
     isRounded: {
       control: "boolean",
       description: "Makes the chip rounded",
+      defaultValue: true,
     },
     fontWeight: {
       control: "select",
@@ -66,13 +68,18 @@ export default {
     style: { control: "object" },
     className: { control: "text" },
     maxWidth: {
-      control: { type: "string", required: false },
+      control: { type: "text", required: false },
       description: "Custom chip width",
       defaultValue: "220px",
     },
     label: {
-      control: "string",
+      control: "text",
       description: "Sets the display label of the chip",
+    },
+    icon: {
+      description:
+        "An element to be placed on the right, ideally an icon. This is clickable if onIconClick is defined.",
+      options: SvgArray,
     },
   },
 } as ComponentMeta<typeof Chip>;
@@ -87,14 +94,14 @@ export const PrimaryChip = Template.bind({});
 PrimaryChip.args = {
   children: "Primary Chip",
   state: "none",
-  isRounded: false,
+  isRounded: true,
 };
 
 export const SecondaryChip = Template.bind({});
 SecondaryChip.args = {
   state: "secondary",
   children: "Secondary Chip",
-  isRounded: false,
+  isRounded: true,
 };
 
 export const DeletableChip = Template.bind({});
@@ -103,7 +110,7 @@ DeletableChip.args = {
   children: "Delete Chip",
   onClick: () => {},
   onDelete: () => {},
-  isRounded: false,
+  isRounded: true,
 };
 
 export const ChipsDemo = () => {

--- a/src/components/Chip/Chip.test.tsx
+++ b/src/components/Chip/Chip.test.tsx
@@ -44,20 +44,16 @@ describe("Chips", () => {
   });
   test("Renders disabled chip", () => {
     const { container } = render(<Chip disabled={true}> Disabled Chip </Chip>);
-    expect(container.getElementsByClassName("nitrozen-disabled").length).toBe(
-      1
-    );
+    expect(container.getElementsByClassName("n-disabled").length).toBe(1);
   });
   test("Renders Secondary state chip", () => {
     const { container } = render(
       <Chip state="secondary"> Selected State Chip </Chip>
     );
-    expect(
-      container.getElementsByClassName("nitrozen-chip-secondary").length
-    ).toBe(1);
+    expect(container.getElementsByClassName("n-chip-secondary").length).toBe(1);
   });
   test("Renders Label with chip", () => {
     const { container } = render(<Chip label="Filter"></Chip>);
-    expect(container.getElementsByClassName("label").length).toBe(1);
+    expect(container.getElementsByClassName("n-chip-label").length).toBe(1);
   });
 });

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -82,17 +82,20 @@ const Chip = (props: ChipProps) => {
       <div
         onClick={handleChipClick}
         style={{ fontWeight: setFontWeight(), ...style }}
-        className={`nitrozen-chip ${setClasses()}`}
+        className={`n-chip ${setClasses()}`}
         {...restProps}
       >
-        <span className="chiptext" style={{ maxWidth: setMaxWidth() }}>
-          {label ? <span className="label">{label}: </span> : null}
+        <span
+          className={`n-chiptext ${label ? "n-label-chip-text" : ""}`}
+          style={{ maxWidth: setMaxWidth() }}
+        >
+          {label ? <span className="n-chip-label">{label}: </span> : null}
           {children ? children : "Submit"}
         </span>
         {deletable && !icon && (
           <span
             data-testid="deletable-cross"
-            className="nitrozen-icon"
+            className="n-icon"
             onClick={removeChip}
           >
             <SvgIcClose style={{ ...defaultIconStyles, ...iconStyle }} />
@@ -101,7 +104,7 @@ const Chip = (props: ChipProps) => {
         {icon && (
           <span
             data-testid="prop-icon"
-            className="nitrozen-icon"
+            className="n-icon"
             onClick={iconClicked}
           >
             <Icon style={{ ...defaultIconStyles, ...iconStyle }} />
@@ -114,9 +117,9 @@ const Chip = (props: ChipProps) => {
 
   function setClasses() {
     let classes: String = "";
-    if (disabled) classes += "nitrozen-disabled ";
+    if (disabled) classes += "n-disabled ";
     if (isRounded) classes += "rounded ";
-    if (state === "secondary") classes += "nitrozen-chip-secondary ";
+    if (state === "secondary") classes += "n-chip-secondary ";
     if (className) classes += className + " ";
 
     return classes;
@@ -140,7 +143,7 @@ Chip.defaultProps = {
   deletable: false,
   disabled: false,
   iconStyle: {},
-  isRounded: false,
+  isRounded: true,
   state: "primary",
   style: {},
   maxWidth: "22rem",


### PR DESCRIPTION
### Changes
- Class name prefix changed to n-  instead of nitrozen-
- Default props for rounded changed to true
- Fixes made for issues in font color when label was visible

<img width="295" alt="Screenshot 2023-02-02 at 12 00 03 AM" src="https://user-images.githubusercontent.com/104082260/216130961-e531aac0-4bf7-40e4-a325-30b6ffb28f7e.png">
<img width="264" alt="Screenshot 2023-02-02 at 12 00 18 AM" src="https://user-images.githubusercontent.com/104082260/216131013-1e7d882a-009f-4222-a88e-d6ac3f8ee07f.png">
