### PR TITLE
chore: label text fix

### DIFF
--- a/src/components/ToggleButton/ToggleButton.scss
+++ b/src/components/ToggleButton/ToggleButton.scss
@@ -137,6 +137,7 @@
       position: absolute;
       cursor: pointer;
       color: $ColorPrimaryGrey80;
+      width: max-content;
 
       &:hover {
         color: $ColorPrimaryGrey100;


### PR DESCRIPTION
Label text goes to the next line after every space. (PFA)

![Screenshot 2023-02-22 at 1 33 25 PM](https://user-images.githubusercontent.com/122079416/221940996-91a119b4-5165-493e-8497-8b88dcc17eb5.png)

Fixed
<img width="1512" alt="Screenshot 2023-02-28 at 11 35 41 PM" src="https://user-images.githubusercontent.com/122079416/221941296-6547bf6a-4560-4b0a-9240-daeb52572537.png">
