### PR TITLE
Implemented feat to allow specifying the number of visible nodes in pagination

### DIFF
--- a/src/components/Pagination/Pagination.test.tsx
+++ b/src/components/Pagination/Pagination.test.tsx
@@ -144,6 +144,23 @@ describe("Pagination", () => {
     expect(dropdown.getAttribute("data-value")).toBe("20");
   });
 
+  it("should set the pagination range to an array of 10 numbers starting from the current page", () => {
+    const setValue = jest.fn();
+    const value = { current: 5 };
+    const setPaginationRange = jest.fn();
+    const onPaginationRange = () => {
+      const range = [];
+      for (let i = value.current; i < value.current + 10; i++) {
+        range.push(i);
+      }
+      setPaginationRange(range);
+    };
+    onPaginationRange();
+    expect(setPaginationRange).toHaveBeenCalledWith([
+      5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+    ]);
+  });
+
   test("onchange should not have been called on initial render", () => {
     const testProps = {
       id: "1",

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -33,6 +33,7 @@ export interface PaginationProps {
   onNextClick?: Function;
   className?: string;
   style?: React.CSSProperties;
+  visiblePagesNodeCount?: number;
 }
 export interface paginationInterface {
   totalCount: number;
@@ -53,6 +54,7 @@ const Pagination = (props: PaginationProps) => {
     onNextClick,
     className,
     style,
+    visiblePagesNodeCount,
     ...restProps
   } = props;
   const [value, setValue] = useState<ConfigProps>(propValue);
@@ -78,7 +80,7 @@ const Pagination = (props: PaginationProps) => {
       return;
     }
     change();
-  }, [value]);
+  }, [value, visiblePagesNodeCount]);
 
   function setDefaults() {
     if (!value.current) {
@@ -146,8 +148,8 @@ const Pagination = (props: PaginationProps) => {
     let maxPageCount = 1800;
     const po = pageSizeOptions
       ? pageSizeOptions.map((p) => {
-          return { text: p.toString(), value: p.toString() };
-        })
+        return { text: p.toString(), value: p.toString() };
+      })
       : [];
     if (!selectedPageSize) {
       setSelectedPageSize(
@@ -181,6 +183,20 @@ const Pagination = (props: PaginationProps) => {
     }
     const width = Math.min(...widths);
 
+    if (visiblePagesNodeCount && visiblePagesNodeCount > 4) {
+      const siblingCount =
+        Math.floor(visiblePagesNodeCount / 2) -
+        (visiblePagesNodeCount % 2 === 0 ? 3 : 2);
+      const paginationRange = usePagination(
+        visiblePagesNodeCount,
+        value.total,
+        value.limit,
+        siblingCount,
+        value.current
+      );
+      setPaginationRange([...paginationRange]);
+      return;
+    }
     if (width <= 768) {
       const paginationRange = usePagination(
         4,
@@ -207,14 +223,12 @@ const Pagination = (props: PaginationProps) => {
         key={index}
         id={index + "node"}
         onClick={(e) => selectedNode(e, i, index)}
-        className={`n-pagination__number_inactive ${
-          i === value.current && "n-pagination__number_active"
-        } ${
-          i === "..." &&
+        className={`n-pagination__number_inactive ${i === value.current && "n-pagination__number_active"
+          } ${i === "..." &&
           popupPosition === index &&
           openPopup &&
           "n-pagination__dot_active"
-        }`}
+          }`}
       >
         {i}
       </div>
@@ -268,9 +282,8 @@ const Pagination = (props: PaginationProps) => {
         key={index}
         id={i}
         onClick={(e) => selectedNode(e, i, index)}
-        className={`n-pagination__search_number_inactive ${
-          i === searchValue && "n-pagination__search_number_active"
-        }`}
+        className={`n-pagination__search_number_inactive ${i === searchValue && "n-pagination__search_number_active"
+          }`}
       >
         {i}
       </div>
@@ -349,9 +362,8 @@ const Pagination = (props: PaginationProps) => {
               <div
                 data-testid="btnPrevious"
                 onClick={previous}
-                className={`n-pagination__prev ${
-                  !showPrev() && "pagination-diabled"
-                }`}
+                className={`n-pagination__prev ${!showPrev() && "pagination-diabled"
+                  }`}
               >
                 <SvgIcChevronLeft />
               </div>
@@ -359,11 +371,10 @@ const Pagination = (props: PaginationProps) => {
                 {listNodeItems()}
                 {openPopup ? (
                   <div
-                    className={`n-pagination__showpopup ${
-                      popupPosition === 1
-                        ? "n-pagination__popup_left"
-                        : "n-pagination__popup_right"
-                    }`}
+                    className={`n-pagination__showpopup ${popupPosition === 1
+                      ? "n-pagination__popup_left"
+                      : "n-pagination__popup_right"
+                      }`}
                     id="menu"
                   >
                     <div className="n-pagination__search_input">
@@ -394,9 +405,8 @@ const Pagination = (props: PaginationProps) => {
               <div
                 data-testid="btnNext"
                 onClick={next}
-                className={`n-pagination__next ${
-                  !showNext() && "pagination-diabled"
-                } `}
+                className={`n-pagination__next ${!showNext() && "pagination-diabled"
+                  } `}
               >
                 <SvgIcChevronRight />
               </div>


### PR DESCRIPTION
- The value of "visiblePagesNodeCount" prop should be greater than 5.
- The number of visible nodes, including ellipses, will always be an odd number.