### PR TITLE
Grid Component Added

### DIFF
--- a/src/components/Grid/Grid.interfaces.ts
+++ b/src/components/Grid/Grid.interfaces.ts
@@ -1,0 +1,36 @@
+export enum ScreenTypes {
+  DESKTOP = "desktop",
+  TABLET = "tablet",
+  MOBILE = "mobile",
+}
+
+export interface CustomWidthObject {
+  columnNumber: 1 | 2 | 3 | 4 | 6;
+  customWidth: number | string;
+}
+
+export interface GridProps {
+  children?: React.ReactNode;
+  style?: React.CSSProperties;
+  onGridContainerClick?: React.MouseEventHandler;
+  columns: {
+    [ScreenTypes.MOBILE]?: 1 | 2 | 3 | 4 | 6;
+    [ScreenTypes.TABLET]?: 1 | 2 | 3 | 4 | 6;
+    [ScreenTypes.DESKTOP]: 1 | 2 | 3 | 4 | 6;
+  };
+  overflow?: {
+    [ScreenTypes.MOBILE]: boolean;
+  };
+  // justifyContent?: {
+  //   [ScreenTypes.MOBILE]?: 'start' | 'end' | 'center';
+  //   [ScreenTypes.TABLET]?: 'start' | 'end' | 'center';
+  //   [ScreenTypes.DESKTOP]?: 'start' | 'end' | 'center';
+  // };
+  // alignItems?: {
+  //   [ScreenTypes.MOBILE]?: 'start' | 'end' | 'center';
+  //   [ScreenTypes.TABLET]?: 'start' | 'end' | 'center';
+  //   [ScreenTypes.DESKTOP]?: 'start' | 'end' | 'center';
+  // };
+  // They can Directly Pass in the Style Props of the Component But need to Confirm if we need we can use this
+  customWidth?: CustomWidthObject[];
+}

--- a/src/components/Grid/Grid.interfaces.ts
+++ b/src/components/Grid/Grid.interfaces.ts
@@ -21,16 +21,5 @@ export interface GridProps {
   overflow?: {
     [ScreenTypes.MOBILE]: boolean;
   };
-  // justifyContent?: {
-  //   [ScreenTypes.MOBILE]?: 'start' | 'end' | 'center';
-  //   [ScreenTypes.TABLET]?: 'start' | 'end' | 'center';
-  //   [ScreenTypes.DESKTOP]?: 'start' | 'end' | 'center';
-  // };
-  // alignItems?: {
-  //   [ScreenTypes.MOBILE]?: 'start' | 'end' | 'center';
-  //   [ScreenTypes.TABLET]?: 'start' | 'end' | 'center';
-  //   [ScreenTypes.DESKTOP]?: 'start' | 'end' | 'center';
-  // };
-  // They can Directly Pass in the Style Props of the Component But need to Confirm if we need we can use this
   customWidth?: CustomWidthObject[];
 }

--- a/src/components/Grid/Grid.scss
+++ b/src/components/Grid/Grid.scss
@@ -1,0 +1,59 @@
+@import "./../../base/base.scss";
+
+.n-grid-container {
+  width: 100%;
+  display: grid;
+  gap: 1.5rem;
+  overflow: hidden;
+}
+
+@media screen and (max-width: 768px) {
+  .n-grid-container {
+    gap: 1rem;
+    -ms-overflow-style: none; /* Internet Explorer 10+ */
+    scrollbar-width: none; /* Firefox */
+  }
+  .n-grid-container::-webkit-scrollbar {
+    display: none; /* Safari and Chrome */
+  }
+
+  .overflow {
+    overflow: scroll;
+    gap: 0.75rem;
+  }
+  .overflow > * {
+    grid-row: 1;
+  }
+}
+
+.n-grid-block-1 {
+  grid-template-columns: repeat(1, 1fr);
+}
+
+.n-grid-block-2 {
+  grid-template-columns: repeat(2, 1fr);
+}
+
+.n-grid-block-3 {
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.n-grid-block-4 {
+  grid-template-columns: repeat(4, 1fr);
+}
+
+.n-grid-block-6 {
+  grid-template-columns: repeat(6, 1fr);
+}
+
+// If we want 8 column or 10 colum or 12 we can just add a new class here and it will automatically get added
+
+.testing-child-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 2rem;
+  color: $TypographyPrimaryColor;
+  background-color: rgb(187, 208, 226);
+  padding: 10px;
+}

--- a/src/components/Grid/Grid.scss
+++ b/src/components/Grid/Grid.scss
@@ -26,28 +26,6 @@
   }
 }
 
-.n-grid-block-1 {
-  grid-template-columns: repeat(1, 1fr);
-}
-
-.n-grid-block-2 {
-  grid-template-columns: repeat(2, 1fr);
-}
-
-.n-grid-block-3 {
-  grid-template-columns: repeat(3, 1fr);
-}
-
-.n-grid-block-4 {
-  grid-template-columns: repeat(4, 1fr);
-}
-
-.n-grid-block-6 {
-  grid-template-columns: repeat(6, 1fr);
-}
-
-// If we want 8 column or 10 colum or 12 we can just add a new class here and it will automatically get added
-
 .testing-child-container {
   display: flex;
   justify-content: center;
@@ -55,5 +33,5 @@
   font-size: 2rem;
   color: $TypographyPrimaryColor;
   background-color: rgb(187, 208, 226);
-  padding: 10px;
+  padding: 1rem;
 }

--- a/src/components/Grid/Grid.stories.tsx
+++ b/src/components/Grid/Grid.stories.tsx
@@ -1,0 +1,79 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import Grid from "./Grid";
+
+export default {
+  title: "Components/Grid",
+  component: Grid,
+} as ComponentMeta<typeof Grid>;
+
+const Template: ComponentStory<typeof Grid> = (args) => {
+  return (
+    <div className="sb-pagination">
+      <Grid {...args}>
+        <div className="testing-child-container">
+          To Check Overflow Feature of Grid use MobileScreen Size
+        </div>
+        <div className="testing-child-container">
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Commodi totam
+          odio aut suscipit quo fugit iusto dolores fuga, eligendi nobis!
+        </div>
+        <div className="testing-child-container">
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Commodi totam
+          odio aut suscipit quo fugit iusto dolores fuga, eligendi nobis!
+        </div>
+        <div className="testing-child-container">
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Commodi totam
+          odio aut suscipit quo fugit iusto dolores fuga, eligendi nobis!
+        </div>
+        <div className="testing-child-container">
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Commodi totam
+          odio aut suscipit quo fugit iusto dolores fuga, eligendi nobis!
+        </div>
+        <div className="testing-child-container">
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Commodi totam
+          odio aut suscipit quo fugit iusto dolores fuga, eligendi nobis!
+        </div>
+      </Grid>
+    </div>
+  );
+};
+
+export const CustomGrid = Template.bind({});
+CustomGrid.args = {
+  columns: {
+    mobile: 2,
+    tablet: 3,
+    desktop: 4,
+  },
+  customWidth: [
+    {
+      columnNumber: 2,
+      customWidth: "150px",
+    },
+    {
+      columnNumber: 4,
+      customWidth: 40,
+    },
+  ],
+};
+
+export const OverflowGrid = Template.bind({});
+OverflowGrid.args = {
+  columns: {
+    mobile: 2,
+    tablet: 3,
+    desktop: 6,
+  },
+  overflow: {
+    mobile: true,
+  },
+};
+
+export const BasicGrid = Template.bind({});
+BasicGrid.args = {
+  columns: {
+    mobile: 1,
+    tablet: 2,
+    desktop: 3,
+  },
+};

--- a/src/components/Grid/Grid.test.tsx
+++ b/src/components/Grid/Grid.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import Grid from "./Grid";
+
+describe("Render a Grid Component", () => {
+  test("Show Grid and Grid Items,it will check Grid Template Classes Based on Column Parameters Change", async () => {
+    const { getByText } = render(
+      <Grid
+        columns={{
+          mobile: 3,
+          tablet: 4,
+          desktop: 6,
+        }}
+        onGridContainerClick={() => jest.fn()}
+      >
+        <div>Child 1</div>
+        <div>Child 2</div>
+        <div>Child 3</div>
+        <div>Child 4</div>
+        <div>Child 5</div>
+        <div>Child 6</div>
+      </Grid>
+    );
+
+    const gridContainer = screen.getByTestId("grid-container");
+    expect(gridContainer.className).toContain(`n-grid-block-6`);
+    expect(gridContainer.className).toContain(`n-grid-container`);
+    fireEvent.click(gridContainer);
+    expect(getByText("Child 1")).toBeInTheDocument();
+    expect(getByText("Child 2")).toBeInTheDocument();
+    expect(getByText("Child 3")).toBeInTheDocument();
+    expect(getByText("Child 4")).toBeInTheDocument();
+    expect(getByText("Child 5")).toBeInTheDocument();
+    expect(getByText("Child 6")).toBeInTheDocument();
+  });
+
+  test("Show Grid and Grid Items on Custom Width For Some Columns", async () => {
+    const { getByText } = render(
+      <Grid
+        columns={{
+          mobile: 2,
+          tablet: 3,
+          desktop: 4,
+        }}
+        customWidth={[
+          { customWidth: "150px", columnNumber: 2 },
+          { customWidth: 40, columnNumber: 4 },
+        ]}
+      >
+        <div>Child 1</div>
+        <div>Child 2</div>
+        <div>Child 3</div>
+        <div>Child 4</div>
+        <div>Child 5</div>
+        <div>Child 6</div>
+      </Grid>
+    );
+
+    const gridContainer = screen.getByTestId("grid-container");
+    expect(gridContainer.className).not.toContain(`n-grid-block-4`);
+    expect(gridContainer.className).toContain(`n-grid-container`);
+    expect(gridContainer).toHaveStyle({
+      "grid-template-columns": "1fr 150px 1fr 40%",
+    });
+    // It will not contain Normal class Because we have Custom Width So the values are dynamically Updated
+    expect(getByText("Child 1")).toBeInTheDocument();
+    expect(getByText("Child 2")).toBeInTheDocument();
+    expect(getByText("Child 3")).toBeInTheDocument();
+    expect(getByText("Child 4")).toBeInTheDocument();
+    expect(getByText("Child 5")).toBeInTheDocument();
+    expect(getByText("Child 6")).toBeInTheDocument();
+  });
+});

--- a/src/components/Grid/Grid.test.tsx
+++ b/src/components/Grid/Grid.test.tsx
@@ -23,7 +23,9 @@ describe("Render a Grid Component", () => {
     );
 
     const gridContainer = screen.getByTestId("grid-container");
-    expect(gridContainer.className).toContain(`n-grid-block-6`);
+    expect(gridContainer).toHaveStyle({
+      "grid-template-columns": "repeat(6,1fr)",
+    });
     expect(gridContainer.className).toContain(`n-grid-container`);
     fireEvent.click(gridContainer);
     expect(getByText("Child 1")).toBeInTheDocument();
@@ -57,7 +59,6 @@ describe("Render a Grid Component", () => {
     );
 
     const gridContainer = screen.getByTestId("grid-container");
-    expect(gridContainer.className).not.toContain(`n-grid-block-4`);
     expect(gridContainer.className).toContain(`n-grid-container`);
     expect(gridContainer).toHaveStyle({
       "grid-template-columns": "1fr 150px 1fr 40%",

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { memo } from "react";
+import { GridProps, ScreenTypes } from "./Grid.interfaces";
+import { useGridStyles } from "./useGridStyles";
+import "./Grid.scss";
+
+const Grid: React.FC<GridProps> = (props) => {
+  const { onGridContainerClick, children, style } = props;
+
+  const { deviceType, customStyles } = useGridStyles(props);
+
+  const isOverflow =
+    props.overflow?.[ScreenTypes.MOBILE] && deviceType === ScreenTypes.MOBILE;
+
+  // If the User has asked for overflow in Mobile size then this will be true and we want every children to follow row 1 only as we want everything in row one
+
+  const customClassName = `n-grid-block-${
+    props.columns[deviceType] || props.columns[ScreenTypes.DESKTOP] || 1
+  }`;
+
+  // Whenever there is no customWidth we will directly render the fixed class based on columns
+
+  return (
+    <div
+      className={`n-grid-container ${
+        !props.customWidth && !isOverflow && customClassName
+      } 
+      ${isOverflow ? "overflow" : ""}  `}
+      style={{ ...style, ...customStyles }}
+      onClick={onGridContainerClick}
+      data-testid={`grid-container`}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default memo(Grid);

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -14,18 +14,9 @@ const Grid: React.FC<GridProps> = (props) => {
 
   // If the User has asked for overflow in Mobile size then this will be true and we want every children to follow row 1 only as we want everything in row one
 
-  const customClassName = `n-grid-block-${
-    props.columns[deviceType] || props.columns[ScreenTypes.DESKTOP] || 1
-  }`;
-
-  // Whenever there is no customWidth we will directly render the fixed class based on columns
-
   return (
     <div
-      className={`n-grid-container ${
-        !props.customWidth && !isOverflow && customClassName
-      } 
-      ${isOverflow ? "overflow" : ""}  `}
+      className={`n-grid-container ${isOverflow ? "overflow" : ""}`}
       style={{ ...style, ...customStyles }}
       onClick={onGridContainerClick}
       data-testid={`grid-container`}

--- a/src/components/Grid/Grid.utils.ts
+++ b/src/components/Grid/Grid.utils.ts
@@ -1,0 +1,34 @@
+import { GridProps, ScreenTypes } from "./Grid.interfaces";
+
+export const calculateCustomGridCss = (
+  props: GridProps,
+  deviceType: ScreenTypes
+) => {
+  let currentCustomStyles = {
+    gridTemplateColumns: "",
+  };
+  if (props.customWidth && props.customWidth.length > 0) {
+    let currentColumns =
+      props.columns[deviceType] || props.columns[ScreenTypes.DESKTOP] || 1;
+    let gridColumns = "";
+    for (let j = 0; j < currentColumns; j++) {
+      const haveCustomWidth = props.customWidth.filter(
+        (el) => el.columnNumber === j + 1
+      );
+      if (haveCustomWidth.length > 0) {
+        if (typeof haveCustomWidth[0].customWidth === "number") {
+          gridColumns += ` ${haveCustomWidth[0].customWidth}%`;
+          // In Number we will make it to percentage
+        } else if (typeof haveCustomWidth[0].customWidth === "string") {
+          gridColumns += ` ${haveCustomWidth[0].customWidth}`;
+          // If its String like 100px 200px 1rem 2rem
+        }
+      } else {
+        // If no Provided any Custom Width it will be remaining to 1fr
+        gridColumns += " 1fr";
+      }
+    }
+    currentCustomStyles.gridTemplateColumns = gridColumns;
+  }
+  return currentCustomStyles;
+};

--- a/src/components/Grid/Grid.utils.ts
+++ b/src/components/Grid/Grid.utils.ts
@@ -29,6 +29,10 @@ export const calculateCustomGridCss = (
       }
     }
     currentCustomStyles.gridTemplateColumns = gridColumns;
+  } else {
+    currentCustomStyles.gridTemplateColumns = `repeat(${
+      props.columns[deviceType] || props.columns[ScreenTypes.DESKTOP] || 1
+    },1fr)`;
   }
   return currentCustomStyles;
 };

--- a/src/components/Grid/index.tsx
+++ b/src/components/Grid/index.tsx
@@ -1,0 +1,1 @@
+export { default } from "./Grid";

--- a/src/components/Grid/useGridStyles.tsx
+++ b/src/components/Grid/useGridStyles.tsx
@@ -1,0 +1,42 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { GridProps, ScreenTypes } from "./Grid.interfaces";
+import { calculateCustomGridCss } from "./Grid.utils";
+
+export const useGridStyles = (props: GridProps) => {
+  const [deviceType, setDeviceType] = useState<ScreenTypes>(
+    ScreenTypes.DESKTOP
+  );
+  const [customStyles, setCustomStyles] = useState<React.CSSProperties>({});
+
+  const updateDeviceType = useCallback(() => {
+    const windowSize = window?.innerWidth;
+    if (windowSize > 768) {
+      setDeviceType(ScreenTypes.DESKTOP);
+    } else if (windowSize > 426) {
+      setDeviceType(ScreenTypes.TABLET);
+    } else {
+      setDeviceType(ScreenTypes.MOBILE);
+    }
+  }, []);
+
+  useEffect(() => {
+    updateDeviceType();
+    window?.addEventListener("resize", updateDeviceType);
+    return () => {
+      window?.removeEventListener("resize", updateDeviceType);
+    };
+  }, [updateDeviceType]);
+
+  useEffect(() => {
+    if (props.customWidth && props.customWidth.length > 0) {
+      setCustomStyles(calculateCustomGridCss(props, deviceType));
+    } else if (Object.keys(customStyles).length > 0) {
+      setCustomStyles({});
+    }
+  }, [props, deviceType]);
+
+  return {
+    deviceType,
+    customStyles,
+  };
+};

--- a/src/components/Grid/useGridStyles.tsx
+++ b/src/components/Grid/useGridStyles.tsx
@@ -28,11 +28,7 @@ export const useGridStyles = (props: GridProps) => {
   }, [updateDeviceType]);
 
   useEffect(() => {
-    if (props.customWidth && props.customWidth.length > 0) {
-      setCustomStyles(calculateCustomGridCss(props, deviceType));
-    } else if (Object.keys(customStyles).length > 0) {
-      setCustomStyles({});
-    }
+    setCustomStyles(calculateCustomGridCss(props, deviceType));
   }, [props, deviceType]);
 
   return {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -23,3 +23,4 @@ export { NudgeManager } from "./Nudge";
 export { default as Table } from "./Table";
 export { default as DateInput } from "./DateInput";
 export { default as Alert } from "./Alert";
+export {default as Grid} from "./Grid";


### PR DESCRIPTION
### NEW FEATURE

User can pass Grid Items as a Children to the Grid Component and basis on the props you define column count for different screen sizes it will render the children inside that grid container. 

Props
style: React.CssProperties
onGridContainerClick: React.MouseEventHandler
columns:{
mobile: number,
tablet: number,
desktop: number
}
overflow:{
mobile: number,
}
customWidth:[{
columnNumber: 1;
customWidth: number;
}]

<img width="1512" alt="Screenshot 2023-03-10 at 4 10 42 PM" src="https://user-images.githubusercontent.com/77038740/224311174-e8767e24-4e75-4982-ba58-45457d2c4458.png">

<img width="1512" alt="Screenshot 2023-03-10 at 4 10 52 PM" src="https://user-images.githubusercontent.com/77038740/224311202-a88be484-c4dc-4f84-9643-f04b65c94209.png">

<img width="1512" alt="Screenshot 2023-03-10 at 5 34 20 PM" src="https://user-images.githubusercontent.com/77038740/224311591-0d0c5f5b-fea0-4556-8056-8f92ff2c88bf.png">


