### PR TITLE
style(alert component): resolving bug of color change on hovering over alert button

### DIFF
--- a/src/components/Alert/Alert.scss
+++ b/src/components/Alert/Alert.scss
@@ -111,14 +111,26 @@
 
     &.n-alert-button-success {
       background-color: $SuccessColor;
+
+      &:hover {
+        background-color: darken($color: $SuccessColor, $amount: 5%);
+      }
     }
 
     &.n-alert-button-warn {
       background-color: $ColorFeedbackWarning50;
+
+      &:hover {
+        background-color: darken($color: #f06d0f, $amount: 5%);
+      }
     }
 
     &.n-alert-button-error {
       background-color: $ColorFeedbackError50;
+
+      &:hover {
+        background-color: darken($color: #f50031, $amount: 5%);
+      }
     }
   }
 


### PR DESCRIPTION
Issue: The buttons inside the alert component are turning to blue color by default on hovering. 
New: 

### Bug Resolution

Please take a look at the success button in the below images to understand the subtle difference in color between the two buttons. Kindly note that this change has been applied to all the states in all the buttons but the following images only show the difference in the "success" state.
Also, note that the LESS variables for `ColorFeedbackWarning50` and `ColorFeedbackError50` were not detected while development, hence I had to use the actual color HEX. 

When the user is not hovering over the button:
<img width="1512" alt="Alert button hover - BEFORE" src="https://user-images.githubusercontent.com/9171367/224637571-cd819633-8594-4b03-b3e8-9cef88164136.png">


When the user hovers over the button:
<img width="1512" alt="Alert button hover - AFTER" src="https://user-images.githubusercontent.com/9171367/224637780-8bd9dfeb-f0f4-4027-a874-aa73acb02acc.png">

