### PR TITLE
fix: added side-effect for value prop in Dropdown

### DIFF
--- a/src/components/Dropdown/Dropdown.test.tsx
+++ b/src/components/Dropdown/Dropdown.test.tsx
@@ -130,4 +130,99 @@ describe("Dropdown", () => {
     const dropdownScroll = getByTestId("dropdown-scroll");
     fireEvent.scroll(dropdownScroll);
   });
+  test("should display the initial selected option", () => {
+    // Arrange
+    const { getByTestId } = render(
+      <Dropdown
+        value={1}
+        label="States"
+        items={DropdownDatasource}
+        onChange={() => {}}
+      />
+    );
+    const dropdown = getByTestId("dropdown-selected-text");
+
+    // Act & Assert
+    expect(dropdown).toHaveTextContent("Maharashtra");
+  });
+
+  test("should update the selected option when the value prop changes", () => {
+    // Arrange
+    const { getByTestId, rerender } = render(
+      <Dropdown
+        value={1}
+        label="States"
+        items={DropdownDatasource}
+        onChange={() => {}}
+      />
+    );
+    const dropdown = getByTestId("dropdown-selected-text");
+
+    // Act
+    rerender(
+      <Dropdown
+        value={2}
+        label="States"
+        items={DropdownDatasource}
+        onChange={() => {}}
+      />
+    );
+
+    // Assert
+    expect(dropdown).toHaveTextContent("Andhra Pradesh");
+  });
+
+  test("should have black arrow icon", () => {
+    // Arrange
+    const { getByTestId } = render(
+      <Dropdown
+        value={1}
+        label="States"
+        items={DropdownDatasource}
+        onChange={() => {}}
+      />
+    );
+    const dropdown = getByTestId("dropdown-arrow-icon");
+
+    // Act
+    const computedStyle = getComputedStyle(dropdown);
+    const color = computedStyle.color;
+
+    // Assert
+    expect(color).toBe("black");
+  });
+  test("should have validation", () => {
+    // Arrange
+    const { getByText } = render(
+      <Dropdown
+        value={1}
+        label="States"
+        items={DropdownDatasource}
+        onChange={() => {}}
+        validationLabel="Error validation message"
+        validationState="error"
+      />
+    );
+    const validation = getByText("Error validation message");
+
+    // Assert
+    expect(validation).toBeInTheDocument();
+  });
+  test("should not show 'All' option, if items prop value is empty and enableSelectAll & multiple is true", () => {
+    // Arrange
+    const { queryByTestId } = render(
+      <Dropdown
+        value={""}
+        label="States"
+        items={[]}
+        onChange={() => {}}
+        enableSelectAll
+        multiple
+      />
+    );
+    const allOption = queryByTestId("all-option");
+
+    // Assert
+    expect(allOption).toBeFalsy();
+  });
 });

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -374,7 +374,9 @@ const Dropdown = (props: DropdownProps) => {
               )}
 
               <div className="n-dropdown-arrow">
-                <SvgIcChevronDown style={{ width: "20px", height: "20px" }} />
+                <SvgIcChevronDown
+                  style={{ width: "20px", height: "20px", color: "black" }}
+                />
               </div>
             </div>
           </div>

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -100,8 +100,8 @@ const Dropdown = (props: DropdownProps) => {
         );
       } else {
         setSelectedItems([]);
+        setSelectedText(generateSelectedText());
       }
-      setSelectedText(generateSelectedText());
       setAllOptions();
     }
   }, [props.value, props.items]);

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -384,33 +384,33 @@ const Dropdown = (props: DropdownProps) => {
             data-testid="dropdown-scroll"
             onScroll={handleScroll}
           >
-            {enableSelectAll && !searchInput && (
-              <span
-                className="n-option ripple"
-                onClick={(e) => {
-                  selectItem("all", ALL_OPTION, e);
-                }}
-                key={`all_${props.items?.length}`}
-              >
-                <div className="n-option-container">
-                  <Checkbox
-                    checkboxValue={allSelected}
-                    value={allSelected}
-                    onChange={setCheckedItem}
-                  >
-                    <span
-                      className={`n-option-image ${
-                        allSelected && "n-dropdown-multicheckbox-selected"
-                      }`}
+            {enableSelectAll && !searchInput && props.items?.length !== 0 && (
+              <>
+                <span
+                  className="n-option ripple"
+                  onClick={(e) => {
+                    selectItem("all", ALL_OPTION, e);
+                  }}
+                  key={`all_${props.items?.length}`}
+                >
+                  <div className="n-option-container">
+                    <Checkbox
+                      checkboxValue={allSelected}
+                      value={allSelected}
+                      onChange={setCheckedItem}
                     >
-                      All
-                    </span>
-                  </Checkbox>
-                </div>
-              </span>
-            )}
-            {enableSelectAll && !searchInput && (
-              <div className="horizantal-divider" />
+                      <span
+                        className={`n-option-image ${
+                          allSelected && "n-dropdown-multicheckbox-selected"
+                        }`}
+                      >
+                        All
+                      </span>
+                    </Checkbox>
+                  </div>
+                </span>
+                <div className="horizantal-divider" />
+              </>
             )}
             {props.items &&
               props.items.length > 0 &&

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -82,16 +82,17 @@ const Dropdown = (props: DropdownProps) => {
     if (!props.multiple) {
       setEnableSelectAll(false);
       if (props.value) {
-        const selected = props.items?.find(
-          (i: ItemProps) => i.value === props.value
-        );
-        setSearchInput(selected?.text ? selected.text : "");
-        setSelected(selected);
+        if (props.value !== selected?.value) {
+          const data = props.items?.find(
+            (i: ItemProps) => i.value === props.value
+          );
+          setSearchInput(data?.text ? data.text : "");
+          setSelected(data);
+        }
       } else {
         setSelected(undefined);
-        setSearchInput("");
-        setSelectedText("");
       }
+      setSelectedText(generateSelectedText());
     } else {
       if (props.value) {
         setSelectedItems(
@@ -99,26 +100,30 @@ const Dropdown = (props: DropdownProps) => {
         );
       } else {
         setSelectedItems([]);
-        setSearchInput("");
-        setSelectedText("");
       }
+      setSelectedText(generateSelectedText());
       setAllOptions();
     }
-  }, [props.value]);
+  }, [props.value, props.items]);
 
   useEffect(() => {
     if (!initialRender.current) {
-      if (!props.multiple)
-        props.value !== selected?.value && props.onChange?.(selected?.value);
-      else {
-        JSON.stringify(props.value ?? []) !== JSON.stringify(selectedItems) &&
-          props.onChange?.(selectedItems);
+      if (!props.multiple) {
+        if (props.value !== selected?.value) {
+          props.onChange?.(selected?.value);
+        }
+        setSelectedText(generateSelectedText());
+      } else if (
+        JSON.stringify(props.value ?? []) !== JSON.stringify(selectedItems)
+      ) {
+        props.onChange?.(selectedItems);
+        setSelectedText(generateSelectedText());
       }
-
       setAllOptions();
+    } else {
+      setSelectedText(generateSelectedText());
     }
     initialRender.current = false;
-    setSelectedText(generateSelectedText());
   }, [selectedItems, selected]);
   useEffect(() => {
     calculateDropUpDown();
@@ -147,11 +152,6 @@ const Dropdown = (props: DropdownProps) => {
     if (!props.multiple) {
       if (props.value) {
         if (props.items?.length) {
-          // eslint-disable-next-line
-          const currentSelected = props.items.find(
-            (i) => i.value == props.value
-          );
-          setSelected(currentSelected);
           setSearchInput(selected?.text ? selected.text : "");
         }
       }
@@ -361,12 +361,14 @@ const Dropdown = (props: DropdownProps) => {
                     onChange={searchInputChange}
                     placeholder={searchInputPlaceholder()}
                     onClick={() => setFocusBorder("n-focused-border")}
-                    onBlur={() => setFocusBorder("")}
+                    onBlur={() => {
+                      setFocusBorder("");
+                      if (searchInput === "")
+                        setSelectedText(generateSelectedText());
+                    }}
                     className={"n-dropdown-search"}
                   />
                 </span>
-              ) : props.disabled ? (
-                <span>Disabled</span>
               ) : (
                 <span>{selectedText}</span>
               )}
@@ -388,6 +390,7 @@ const Dropdown = (props: DropdownProps) => {
                 onClick={(e) => {
                   selectItem("all", ALL_OPTION, e);
                 }}
+                key={`all_${props.items?.length}`}
               >
                 <div className="n-option-container">
                   <Checkbox
@@ -413,8 +416,8 @@ const Dropdown = (props: DropdownProps) => {
               props.items.length > 0 &&
               props?.items?.map((item: ItemProps, index: number) => (
                 <span
-                  key={index}
-                  data-value={item.value}
+                  key={`${index}_${props.items?.length}`}
+                  data-value={item?.value}
                   className={`n-option ripple ${
                     item === selected && "selected"
                   } ${item?.isGroupLabel && "n-option-group-label"}`}
@@ -423,25 +426,25 @@ const Dropdown = (props: DropdownProps) => {
                   <div className="n-option-container">
                     {props.multiple && !item?.isGroupLabel ? (
                       <Checkbox
-                        checkboxValue={item.value}
+                        checkboxValue={item?.value}
                         checkArray={[...selectedItems]}
                         onChange={setCheckedItem}
-                        value={item.value}
+                        value={item?.value}
                       >
                         <span
                           className={`n-option-image ${
-                            selectedItems.includes(item.value) &&
+                            selectedItems.includes(item?.value) &&
                             "n-dropdown-multicheckbox-selected"
                           }`}
                         >
                           {item.logo && (
                             <img
                               className="n-option-logo"
-                              src={item.logo}
+                              src={item?.logo}
                               alt="logo"
                             />
                           )}{" "}
-                          {item.text}
+                          {item?.text}
                         </span>
                       </Checkbox>
                     ) : (

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -370,11 +370,12 @@ const Dropdown = (props: DropdownProps) => {
                   />
                 </span>
               ) : (
-                <span>{selectedText}</span>
+                <span data-testid="dropdown-selected-text">{selectedText}</span>
               )}
 
               <div className="n-dropdown-arrow">
                 <SvgIcChevronDown
+                  data-testid="dropdown-arrow-icon"
                   style={{ width: "20px", height: "20px", color: "black" }}
                 />
               </div>
@@ -389,6 +390,7 @@ const Dropdown = (props: DropdownProps) => {
             {enableSelectAll && !searchInput && props.items?.length !== 0 && (
               <>
                 <span
+                  data-testid="all-option"
                   className="n-option ripple"
                   onClick={(e) => {
                     selectItem("all", ALL_OPTION, e);
@@ -504,6 +506,7 @@ const Dropdown = (props: DropdownProps) => {
       {props.validationState && (
         <Validation
           className="n-dropdown-validation"
+          data-testid="dropdown-validation"
           isHidden={props.validationState ? false : true}
           label={props.validationLabel}
           validationState={props.validationState}


### PR DESCRIPTION
Following issues were resolved:

1. Dropdown `selectedItems` state was not getting updated if there was an update in the passed `value` prop.
2. In multiple Dropdown, if `enableSelectAll` prop is set to true. In this case, selecting all the options from the options list doesn't set `All` option checkbox to true/checked.
3. If `items` prop value is changed, dropdown option wasn't reflecting the updated options list. (Issue related to React key prop)
4. On clicking clear button in searchable dropdown, it clears the search input as expected but when focused out of the input, it should display the last selected option(if selected) or the placeholder value. 
5. In the `Disabled` state, dropdown displays "Disabled" text instead of displaying the value passed in `value` prop, otherwise it should be displaying the placeholder text.
6. if `items` prop value is empty and `enableSelectAll` is true, then it shows `All` option checkbox as true/checked.
7. Currently, Dropdown arrow has a golden color. It should be changed to black color.