### PR TITLE
feat: added freeze column feature in table

### DIFF
--- a/src/components/Table/Table.scss
+++ b/src/components/Table/Table.scss
@@ -8,7 +8,7 @@
 
 .left-freezed-border,
 .right-freezed-border {
-  position: sticky;
+  position: absolute;
   height: 100%;
   top: 0;
   z-index: 10;

--- a/src/components/Table/Table.scss
+++ b/src/components/Table/Table.scss
@@ -2,6 +2,21 @@
 
 .n-table {
   width: 100%;
+  overflow: scroll;
+  position: relative;
+}
+
+.left-freezed-border,
+.right-freezed-border {
+  position: sticky;
+  height: 100%;
+  top: 0;
+  z-index: 10;
+  pointer-events: none;
+  width: 4px;
+  background: #f5f5f5;
+  border-radius: 250px;
+  border: 1px solid #e0e0e0;
 }
 
 .n-main-table {
@@ -10,6 +25,7 @@
   border-spacing: 0;
   width: 100%;
   user-select: none;
+  position: relative;
 
   thead {
     color: $ColorPrimaryInverse;
@@ -57,6 +73,7 @@
     padding: 16px;
     border-top: $TableBorderWidth solid $ColorSparkleGrey40;
     font-size: 14px;
+    background: #fff;
   }
 
   td:last-child {

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -76,6 +76,16 @@ export default {
       ],
     },
     footer: { control: "text" },
+    freezeLeftColumns: {
+      control: "number",
+      defaultValue: 0,
+      description: "Number of columns to freeze from the left",
+    },
+    freezeRightColumns: {
+      control: "number",
+      defaultValue: 0,
+      description: "Number of columns to freeze from the left",
+    },
     rowStyle: {
       control: "select",
       options: ["simple", "zebra"],

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -184,6 +184,12 @@ const Table: React.FC<TableProps> = (props) => {
 
   useLayoutEffect(() => {
     handleScroll();
+    if (typeof window !== undefined)
+      window.addEventListener("resize", handleScroll);
+    return () => {
+      if (typeof window !== undefined)
+        window.removeEventListener("resize", handleScroll);
+    };
   }, []);
 
   return (

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useState, useEffect } from "react";
+import React, { memo, useState, useRef, useLayoutEffect } from "react";
 import NitrozenId from "../../utils/uuids";
 import "./Table.scss";
 import {
@@ -22,6 +22,8 @@ export interface TableProps {
   showColumnDivider?: boolean;
   customClassName?: string;
   customStyle?: React.CSSProperties;
+  freezeLeftColumns?: number;
+  freezeRightColumns?: number;
 }
 
 const Table: React.FC<TableProps> = (props) => {
@@ -34,6 +36,7 @@ const Table: React.FC<TableProps> = (props) => {
     customClassName,
   } = props;
   const [clickedIds, setClickedIds] = useState<number[]>([]);
+  const tableRef = useRef<any>(null);
 
   /**
    *
@@ -78,12 +81,118 @@ const Table: React.FC<TableProps> = (props) => {
       props.onRowClick?.(index);
     };
   };
+  const throttle = (callback: FrameRequestCallback) => {
+    let rafId: number;
+
+    const throttled = () => {
+      cancelAnimationFrame(rafId);
+      rafId = requestAnimationFrame(callback);
+    };
+
+    return throttled;
+  };
+
+  const freezeLeft = () => {
+    const table = tableRef.current;
+    if (!table) return;
+
+    const { scrollLeft } = table;
+
+    const frozenColumnsTh = table?.querySelectorAll(
+      "th:nth-child(-n+" + props.freezeLeftColumns + ")"
+    ) as NodeListOf<HTMLElement>;
+    let leftTh = 0;
+    Array.from(frozenColumnsTh)?.forEach((column) => {
+      column.style.position = "sticky";
+      column.style.left = leftTh + "px";
+      leftTh += column.getBoundingClientRect().width;
+    });
+
+    const frozenColumnsTbodyTr = table?.querySelectorAll(
+      "tbody > tr"
+    ) as NodeListOf<HTMLElement>;
+
+    frozenColumnsTbodyTr?.forEach((tr) => {
+      const frozenColumnsTd = tr?.querySelectorAll(
+        "td:nth-child(-n+" + props.freezeLeftColumns + ")"
+      ) as NodeListOf<HTMLElement>;
+      let leftTd = 0;
+      Array.from(frozenColumnsTd)?.forEach((column) => {
+        column.style.position = "sticky";
+        column.style.left = leftTd + "px";
+        leftTd += column.getBoundingClientRect().width;
+      });
+    });
+
+    const afterDiv = table?.querySelector(
+      ".left-freezed-border"
+    ) as HTMLElement;
+    afterDiv.style.left = leftTh + scrollLeft + "px";
+  };
+
+  const freezeRight = () => {
+    const table = tableRef.current;
+    if (!table) return;
+
+    const { scrollLeft } = table;
+
+    const frozenColumnsTh = table?.querySelectorAll(
+      "th:nth-last-child(-n+" + props.freezeRightColumns + ")"
+    ) as NodeListOf<HTMLElement>;
+    let rightTh = 0;
+    Array.from(frozenColumnsTh)
+      ?.reverse()
+      .forEach((column) => {
+        column.style.position = "sticky";
+        column.style.right = rightTh + "px";
+        rightTh += column.getBoundingClientRect().width;
+      });
+
+    const frozenColumnsTbodyTr = table?.querySelectorAll(
+      "tbody > tr"
+    ) as NodeListOf<HTMLElement>;
+
+    frozenColumnsTbodyTr?.forEach((tr) => {
+      const frozenColumnsTd = tr?.querySelectorAll(
+        "td:nth-last-child(-n+" + props.freezeRightColumns + ")"
+      ) as NodeListOf<HTMLElement>;
+      let rightTd = 0;
+      Array.from(frozenColumnsTd)
+        ?.reverse()
+        .forEach((column) => {
+          column.style.position = "sticky";
+          column.style.right = rightTd + "px";
+          rightTd += column.getBoundingClientRect().width;
+        });
+    });
+
+    const afterDiv = table?.querySelector(
+      ".right-freezed-border"
+    ) as HTMLElement;
+    afterDiv.style.right = rightTh - scrollLeft + "px";
+  };
+
+  const throttledFreezeLeft = throttle(freezeLeft);
+  const throttledFreezeRight = throttle(freezeRight);
+
+  const handleScroll = () => {
+    if (props.freezeLeftColumns && Number(props.freezeLeftColumns) > 0)
+      throttledFreezeLeft();
+    if (props.freezeRightColumns && Number(props.freezeRightColumns) > 0)
+      throttledFreezeRight();
+  };
+
+  useLayoutEffect(() => {
+    handleScroll();
+  }, []);
 
   return (
     <div
       className={`n-table ${customClassName ? customClassName : ""}`}
       data-testid={`table-${id}`}
       style={customStyle ?? {}}
+      ref={tableRef}
+      onScroll={handleScroll}
     >
       <table className="n-main-table">
         <thead>
@@ -228,6 +337,8 @@ const Table: React.FC<TableProps> = (props) => {
           </tfoot>
         ) : null}
       </table>
+      {!!props.freezeLeftColumns && <div className="left-freezed-border" />}
+      {!!props.freezeRightColumns && <div className="right-freezed-border" />}
     </div>
   );
 };
@@ -244,6 +355,8 @@ Table.defaultProps = {
   getCheckedItems: () => {},
   allCheckClicked: () => {},
   showColumnDivider: true,
+  freezeLeftColumns: 0,
+  freezeRightColumns: 0,
 };
 
 export default memo(Table);

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useState, useRef, useLayoutEffect } from "react";
+import React, { memo, useState, useRef, useEffect } from "react";
 import NitrozenId from "../../utils/uuids";
 import "./Table.scss";
 import {
@@ -182,7 +182,7 @@ const Table: React.FC<TableProps> = (props) => {
       throttledFreezeRight();
   };
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     handleScroll();
     if (typeof window !== undefined)
       window.addEventListener("resize", handleScroll);
@@ -190,7 +190,7 @@ const Table: React.FC<TableProps> = (props) => {
       if (typeof window !== undefined)
         window.removeEventListener("resize", handleScroll);
     };
-  }, []);
+  }, [tableRow]);
 
   return (
     <div


### PR DESCRIPTION
Description: 
This PR introduces the freeze columns functionality in the Table component, allowing users to freeze a specified number of columns on the left and right sides of the table while horizontally scrolling through the remaining columns.

The implementation includes the following features:
- Ability to freeze a configurable number of columns on both the left and right sides of the table.
- Dynamic adjustment of column freezing based on user input or table content.
- Smooth scrolling behavior with accurate positioning of frozen columns during horizontal scroll.

Changes Made
- Added new `freezeLeftColumns` and `freezeRightColumns` props to the Table component, allowing users to specify the number of columns to freeze on each side.
- Implemented the necessary JavaScript and CSS logic to calculate and apply the freezing behavior on the specified columns.
- Added appropriate styles and positioning to ensure the frozen columns remain fixed while scrolling horizontally.
- Updated the table rendering logic to dynamically adjust the column widths and content alignment based on the frozen columns.
- Modified the unit test suite to include test cases for the freeze columns functionality, covering different scenarios and edge cases.

Screenshots:


https://github.com/gofynd/nitrozen-react/assets/129382870/e0017b27-095e-4205-b6e5-7e6e19432b2b


