### PR TITLE
Refactor: Make measurements dynamic based on font-size

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ function MyComponent() {
 
 ### 🚨 Note:
 
-> The library sets default font size as 10px. Hence if you are planning to use 10px as base font size in your app, you need to add the same to your code as well.
+> The library uses default font size as 10px. Hence if you are planning to use 10px as base font size, you need to add the same to your code as well.
 
 ```css
 html,

--- a/README.md
+++ b/README.md
@@ -42,6 +42,30 @@ function MyComponent() {
 
 ![button](https://github.com/gofynd/nitrozen-react/blob/main/src/assets/sb-buttons.png)
 
+### 🚨 Note:
+
+> The library sets default font size as 10px. Hence if you are planning to use 10px as base font size in your app, you need to add the same to your code as well.
+
+```css
+html,
+body {
+  font-size: 10px;
+}
+```
+
+If you wish to use any other base font-size apart from 10px, you need to add these following:
+
+```css
+:root {
+  --BaseFontSize: <your font size>; /* number as integer without unit */
+}
+
+html,
+body {
+  font-size: <your font size>; /* number with unit */
+}
+```
+
 ## 🔥 Components List:
 
 - [Alert](https://opensource.gofynd.io/nitrozen-react/?path=/docs/components-alert--button-less-alert)

--- a/src/base/base.scss
+++ b/src/base/base.scss
@@ -4,3 +4,4 @@
 // @import './common.scss';
 @import "./mixins.scss";
 @import "./media.scss";
+@import "./functions.scss";

--- a/src/base/common.scss
+++ b/src/base/common.scss
@@ -5,7 +5,7 @@
 
 html,
 body {
-  font-size: $BaseFontSize;
+  font-size: calc($BaseFontSize * 1px); // converting integer to px
 }
 
 .nitrozen-scrollbar {

--- a/src/base/functions.scss
+++ b/src/base/functions.scss
@@ -1,0 +1,3 @@
+@function pxToRem($pxValue) {
+  @return calc((#{$pxValue} / #{$BaseFontSize}) * 1rem);
+}

--- a/src/base/functions.scss
+++ b/src/base/functions.scss
@@ -1,3 +1,9 @@
+/**
+ * Converts pixel value to rem value based on the base font size.
+ *
+ * @param {number} $pxValue - The pixel value to be converted to rem.
+ * @return {number} - The converted rem value.
+ */
 @function pxToRem($pxValue) {
   @return calc((#{$pxValue} / #{$BaseFontSize}) * 1rem);
 }

--- a/src/base/storybook.scss
+++ b/src/base/storybook.scss
@@ -44,7 +44,7 @@ $Spray: #8ac5d4;
   p {
     margin: 0.9rem 0;
     padding: 0;
-    font-size: $BaseFontSize + 4;
+    font-size: pxToRem(14);
   }
 }
 

--- a/src/base/variable.scss
+++ b/src/base/variable.scss
@@ -1,7 +1,7 @@
 @import "./fonts.scss";
 
 $DefaultColor: #2e31be;
-$BaseFontSize: var(--BaseFontSize, 10);
+$BaseFontSize: var(--BaseFontSize, 10); // default is 10
 $PrimaryColor: var(--PrimaryColor, $DefaultColor);
 $PrimaryHoverColor: var(--PrimaryHoverColor, #2e31a1);
 $PrimaryDisabledColor: var(--PrimaryDisabledColor, #b5ffe7);

--- a/src/base/variable.scss
+++ b/src/base/variable.scss
@@ -1,7 +1,7 @@
 @import "./fonts.scss";
 
-$BaseFontSize: 10px;
 $DefaultColor: #2e31be;
+$BaseFontSize: var(--BaseFontSize, 10);
 $PrimaryColor: var(--PrimaryColor, $DefaultColor);
 $PrimaryHoverColor: var(--PrimaryHoverColor, #2e31a1);
 $PrimaryDisabledColor: var(--PrimaryDisabledColor, #b5ffe7);

--- a/src/components/Alert/Alert.scss
+++ b/src/components/Alert/Alert.scss
@@ -3,11 +3,11 @@
 .n-alert {
   box-sizing: border-box;
   display: flex;
-  padding: 1rem;
-  gap: 0.8rem;
+  padding: pxToRem(10);
+  gap: pxToRem(8);
   cursor: default;
-  border-radius: 1.6rem;
-  border: 0.1rem solid $LabelColor;
+  border-radius: pxToRem(16);
+  border: pxToRem(1) solid $LabelColor;
   color: $TypographyPrimaryColor;
   font-size: pxToRem(12);
   font-family: $PrimaryFont;
@@ -32,34 +32,34 @@
 
   &.n-alert-info {
     background: $ColorPrimary20;
-    border: 0.1rem solid $ColorPrimary50;
+    border: pxToRem(1) solid $ColorPrimary50;
   }
 
   &.n-alert-success {
     background: $Bubbles;
-    border: 0.1rem solid $SuccessColor;
+    border: pxToRem(1) solid $SuccessColor;
   }
 
   &.n-alert-warn {
     background: $ColorFeedbackWarning20;
-    border: 0.1rem solid $ColorFeedbackWarning50;
+    border: pxToRem(1) solid $ColorFeedbackWarning50;
   }
 
   &.n-alert-error {
     background: $ColorFeedbackError20;
-    border: 0.1rem solid $ColorFeedbackError50;
+    border: pxToRem(1) solid $ColorFeedbackError50;
   }
 
   &.n-alert-loader-container {
     background: $ColorPrimary20 !important;
-    border: 0.1rem solid $ColorPrimary50;
+    border: pxToRem(1) solid $ColorPrimary50;
   }
 
   .n-alert-flex {
     display: flex;
     flex-direction: row;
     justify-content: space-between;
-    column-gap: 8rem;
+    column-gap: pxToRem(80);
     width: 100%;
     align-items: center;
 
@@ -67,7 +67,7 @@
       flex-direction: column;
       align-items: unset;
       justify-content: center;
-      row-gap: 1.2rem;
+      row-gap: pxToRem(12);
 
       .n-alert-button-container {
         display: flex;
@@ -79,7 +79,7 @@
   .n-alert-text-icon-wrapper {
     display: flex;
     align-items: center;
-    column-gap: 0.4rem;
+    column-gap: pxToRem(4);
 
     .n-alert-icon {
       font-size: pxToRem(28.8);
@@ -93,7 +93,7 @@
         color: $WhiteColor;
         border-radius: 100%;
         font-size: medium;
-        padding: 0.5rem;
+        padding: pxToRem(5);
       }
 
       &.n-alert-icon-warn {
@@ -107,7 +107,7 @@
   }
 
   .n-alert-button {
-    padding: 0.4rem 1.2rem;
+    padding: pxToRem(4) pxToRem(12);
 
     &.n-alert-button-success {
       background-color: $SuccessColor;
@@ -158,17 +158,17 @@
 
   .n-alert-loader {
     animation: spin 2s linear infinite;
-    height: 2.4rem;
+    height: pxToRem(24);
   }
 
   .loader {
-    border: 0.4rem solid #f3f3f3;
-    border-top: 0.4rem solid #3535f3;
-    border-right: 0.4rem solid #f7ab20;
-    border-bottom: 0.4rem solid #1eccb0;
+    border: pxToRem(4) solid #f3f3f3;
+    border-top: pxToRem(4) solid #3535f3;
+    border-right: pxToRem(4) solid #f7ab20;
+    border-bottom: pxToRem(4) solid #1eccb0;
     border-radius: 50%;
-    width: 2rem;
-    height: 2rem;
+    width: pxToRem(20);
+    height: pxToRem(20);
     animation: spin 2s linear infinite;
   }
 

--- a/src/components/Alert/Alert.scss
+++ b/src/components/Alert/Alert.scss
@@ -9,7 +9,7 @@
   border-radius: 1.6rem;
   border: 0.1rem solid $LabelColor;
   color: $TypographyPrimaryColor;
-  font-size: $BaseFontSize + 2;
+  font-size: pxToRem(12);
   font-family: $PrimaryFont;
 
   &:focus {
@@ -19,14 +19,14 @@
   &.n-alert-full-width {
     .n-alert-label-text,
     .n-alert-text {
-      font-size: $BaseFontSize + 6;
+      font-size: pxToRem(16);
     }
   }
 
   &.n-alert-link-button-container {
     .n-alert-label-text,
     .n-alert-text {
-      font-size: $BaseFontSize + 4;
+      font-size: pxToRem(14);
     }
   }
 
@@ -82,7 +82,7 @@
     column-gap: 0.4rem;
 
     .n-alert-icon {
-      font-size: $BaseFontSize + 18.8;
+      font-size: pxToRem(28.8);
 
       &.n-alert-icon-info {
         color: $ColorPrimary50;

--- a/src/components/Autocomplete/Autocomplete.scss
+++ b/src/components/Autocomplete/Autocomplete.scss
@@ -4,13 +4,13 @@
   position: relative;
   .n-autocomplete {
     font-family: $PrimaryFont;
-    gap: 0.8rem;
+    gap: pxToRem(8);
     margin-left: auto;
     margin-right: auto;
-    height: 4.8rem;
+    height: pxToRem(48);
     background: $ColorPrimaryInverse;
-    border: 0.1rem solid $ColorPrimaryGrey60;
-    border-radius: 1.6rem;
+    border: pxToRem(1) solid $ColorPrimaryGrey60;
+    border-radius: pxToRem(16);
     position: relative;
     display: flex;
     color: $ColorPrimaryGrey80;
@@ -71,34 +71,34 @@
       cursor: not-allowed;
     }
     &.n-autocomplete-focussed {
-      border: 2px solid $PrimaryColor;
+      border: pxToRem(2) solid $PrimaryColor;
     }
     .n-pre-input-icon {
-      left: 1.2rem;
+      left: pxToRem(12);
     }
     .n-suf-input-icon {
-      right: 1.2rem;
+      right: pxToRem(12);
     }
     input[type="text"] {
       -webkit-appearance: none;
       appearance: none;
       border: none;
-      border-radius: 1.6rem;
+      border-radius: pxToRem(16);
       width: 100%;
-      padding: 0.8rem 1.6rem;
-      padding-right: 1.2rem;
+      padding: pxToRem(8) pxToRem(16);
+      padding-right: pxToRem(12);
       color: $ColorPrimaryGrey100;
       outline: none;
       font-family: "NitrozenType", helvetica, arial, sans-serif;
       font-weight: 500;
       text-transform: none;
-      font-size: 1.6rem;
-      letter-spacing: -0.008rem;
+      font-size: pxToRem(16);
+      letter-spacing: pxToRem(-0.08);
       line-height: 1.5;
       &::placeholder {
         /* Chrome, Firefox, Opera, Safari 10.1+ */
         color: $ColorPrimaryGrey80;
-        font-size: 1.6rem;
+        font-size: pxToRem(16);
         opacity: 1; /* Firefox */
       }
       &:hover {
@@ -110,11 +110,11 @@
       }
     }
     input[type="text"].n-pre-input {
-      padding-left: 4.8rem;
+      padding-left: pxToRem(48);
     }
 
     input[type="text"].n-suf-input {
-      padding-right: 4.8rem;
+      padding-right: pxToRem(48);
     }
   }
 
@@ -123,9 +123,9 @@
     flex-direction: column;
     align-items: flex-start;
     background: $ColorPrimaryInverse;
-    box-shadow: 0rem 0.4rem 1.6rem $Shadow;
-    border-radius: 2.4rem;
-    max-height: 33.6rem;
+    box-shadow: pxToRem(0) pxToRem(4) pxToRem(16) $Shadow;
+    border-radius: pxToRem(24);
+    max-height: pxToRem(336);
     overflow-y: scroll;
     position: absolute;
     z-index: $ZIndex3;
@@ -135,16 +135,16 @@
     .n-autocomplete-result-item {
       display: flex;
       align-items: center;
-      height: 4.2rem;
+      height: pxToRem(42);
       font-style: normal;
       font-weight: 500;
-      font-size: 1.6rem;
-      line-height: 2.4rem;
-      border-radius: 1.6rem;
+      font-size: pxToRem(16);
+      line-height: pxToRem(24);
+      border-radius: pxToRem(16);
       width: 100%;
       letter-spacing: -0.005em;
       color: $ColorPrimaryGrey100;
-      padding: 1.2rem;
+      padding: pxToRem(12);
       cursor: pointer;
       &:hover,
       &.n-autocomplete-result-item-active {
@@ -155,8 +155,8 @@
         display: flex;
         align-items: center;
         justify-content: center;
-        font-size: 1.6rem;
-        padding: 0.4rem;
+        font-size: pxToRem(16);
+        padding: pxToRem(4);
         color: $ColorPrimaryGrey100;
         &.n-autocomplete-result-item-text {
           white-space: nowrap;
@@ -164,8 +164,8 @@
           text-overflow: ellipsis;
         }
         &.n-autocomplete-result-item-icon {
-          height: 3.2rem;
-          width: 3.2rem;
+          height: pxToRem(32);
+          width: pxToRem(32);
           border-radius: 50%;
           background-color: $ColorPrimaryGrey20;
         }

--- a/src/components/Badge/Badge.scss
+++ b/src/components/Badge/Badge.scss
@@ -22,7 +22,7 @@
   cursor: default;
   border-radius: 0.4rem;
   color: $WhiteColor;
-  font-size: $BaseFontSize + 2;
+  font-size: pxToRem(12);
   white-space: nowrap;
   font-family: $PrimaryFont;
   line-height: 1.8rem;
@@ -84,7 +84,7 @@
   font-weight: 500;
   gap: 1.6rem;
   @include nitrozen-border-secondary-disable;
-  font-size: $BaseFontSize + 6;
+  font-size: pxToRem(16);
 }
 .nitrozen-badge-story-table-row {
   display: grid;
@@ -104,15 +104,15 @@
   width: 80vw;
 }
 .nitrozen-badge-small {
-  font-size: $BaseFontSize + 2;
+  font-size: pxToRem(12);
   line-height: 1.6rem;
   letter-spacing: -0.005em;
 }
 .nitrozen-badge-medium {
-  font-size: $BaseFontSize + 4;
+  font-size: pxToRem(14);
 }
 .nitrozen-badge-large {
-  font-size: $BaseFontSize + 8;
+  font-size: pxToRem(18);
   padding: 0.4rem 0.8rem;
   line-height: 2.4rem;
   letter-spacing: -0.005em;

--- a/src/components/Badge/Badge.scss
+++ b/src/components/Badge/Badge.scss
@@ -1,11 +1,11 @@
 @import "./../../base/base.scss";
 
 @mixin nitrozen-border-primary {
-  border: 0.1rem solid $PrimaryColor;
+  border: pxToRem(1) solid $PrimaryColor;
 }
 
 @mixin nitrozen-border-secondary-disable {
-  border: 0.1rem solid $SecondaryDisabledColor;
+  border: pxToRem(1) solid $SecondaryDisabledColor;
 }
 
 @mixin nitrozen-vertical-horizontal-center {
@@ -17,10 +17,10 @@
 
 .nitrozen-badge {
   @include nitrozen-vertical-horizontal-center;
-  height: 1.6rem;
-  padding: 0.4rem 0.8rem;
+  height: pxToRem(16);
+  padding: pxToRem(4) pxToRem(8);
   cursor: default;
-  border-radius: 0.4rem;
+  border-radius: pxToRem(4);
   color: $WhiteColor;
   font-size: pxToRem(12);
   white-space: nowrap;
@@ -31,7 +31,7 @@
     outline: none;
   }
   &.nitrozen-badge-default {
-    border: 0.1rem solid $Zambezi;
+    border: pxToRem(1) solid $Zambezi;
     color: $Zambezi;
   }
   &.nitrozen-badge-info {
@@ -39,19 +39,19 @@
     color: $PrimaryColor;
   }
   &.nitrozen-badge-success {
-    border: 0.1rem solid $SuccessColor;
+    border: pxToRem(1) solid $SuccessColor;
     color: $SuccessColor;
   }
   &.nitrozen-badge-warn {
-    border: 0.1rem solid $ColorFeedbackWarning20;
+    border: pxToRem(1) solid $ColorFeedbackWarning20;
     color: $ColorFeedbackWarning80;
   }
   &.nitrozen-badge-error {
-    border: 0.1rem solid $ErrorColor;
+    border: pxToRem(1) solid $ErrorColor;
     color: $ErrorColor;
   }
   &.nitrozen-badge-disable {
-    border: 0.1rem solid $LabelColor;
+    border: pxToRem(1) solid $LabelColor;
     color: $LabelColor;
   }
   &.nitrozen-badge-default-fill {
@@ -82,30 +82,30 @@
 .nitrozen-badge-story-table {
   font-family: "Inter";
   font-weight: 500;
-  gap: 1.6rem;
+  gap: pxToRem(16);
   @include nitrozen-border-secondary-disable;
   font-size: pxToRem(16);
 }
 .nitrozen-badge-story-table-row {
   display: grid;
   grid-template-columns: 3fr 1fr 1fr 1fr 1fr;
-  gap: 3.2rem;
+  gap: pxToRem(32);
   @include nitrozen-border-secondary-disable;
-  border-radius: 0.4rem;
-  padding: 1rem;
+  border-radius: pxToRem(4);
+  padding: pxToRem(10);
   width: 80vw;
 }
 .nitrozen-badge-story-table-row-header {
   display: grid;
   grid-template-columns: 3fr 1fr 1fr 1fr 1fr;
-  gap: 3.2rem;
-  border-bottom: 0.1rem solid black;
-  padding: 1rem;
+  gap: pxToRem(32);
+  border-bottom: pxToRem(1) solid black;
+  padding: pxToRem(10);
   width: 80vw;
 }
 .nitrozen-badge-small {
   font-size: pxToRem(12);
-  line-height: 1.6rem;
+  line-height: pxToRem(16);
   letter-spacing: -0.005em;
 }
 .nitrozen-badge-medium {
@@ -113,14 +113,14 @@
 }
 .nitrozen-badge-large {
   font-size: pxToRem(18);
-  padding: 0.4rem 0.8rem;
-  line-height: 2.4rem;
+  padding: pxToRem(4) pxToRem(8);
+  line-height: pxToRem(24);
   letter-spacing: -0.005em;
 }
 .nitrogen-badge-background {
   width: 100%;
   @include nitrozen-vertical-horizontal-center;
-  padding: 0.8rem;
+  padding: pxToRem(8);
 }
 
 .nitrozen-badge-truncate {
@@ -129,20 +129,20 @@
   display: inline-block;
   text-overflow: ellipsis;
   white-space: nowrap;
-  max-width: 400px;
+  max-width: pxToRem(400);
 }
 
 .nitrozen-badge-small-badge-icon {
   @include nitrozen-vertical-horizontal-center;
-  margin-right: 0.5rem;
+  margin-right: pxToRem(5);
 }
 
 .nitrozen-badge-medium-badge-icon {
   @include nitrozen-vertical-horizontal-center;
-  margin-right: 0.6rem;
+  margin-right: pxToRem(6);
 }
 
 .nitrozen-badge-large-badge-icon {
   @include nitrozen-vertical-horizontal-center;
-  margin-right: 0.7rem;
+  margin-right: pxToRem(7);
 }

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -1,13 +1,13 @@
 @import "./../../base/base.scss";
 
 .n-button {
-  height: 4rem;
+  height: pxToRem(40);
   cursor: pointer;
   box-shadow: none;
   font-family: $PrimaryFont;
-  font-size: $BaseFontSize + 5;
+  font-size: pxToRem(15);
   font-weight: 700;
-  line-height: 1.8rem;
+  line-height: pxToRem(18);
   text-align: center;
   outline: none;
   border: 0;
@@ -15,9 +15,9 @@
   background: none;
   text-decoration: none;
   box-sizing: border-box;
-  letter-spacing: 0.05rem;
-  padding: 0rem 3rem;
-  border-radius: 0.3rem;
+  letter-spacing: pxToRem(0.5);
+  padding: 0rem pxToRem(30);
+  border-radius: pxToRem(3);
   color: $WhiteColor;
 
   &:disabled {
@@ -204,43 +204,43 @@
 }
 
 .n-button-rounded {
-  border-radius: 3.4rem;
-  padding: 0rem 3.2rem;
+  border-radius: pxToRem(34);
+  padding: 0rem pxToRem(32);
 }
 
 .n-button-large {
-  padding: 1.6rem 2.4rem; // 1.6rem 0.6rem;
-  height: 5.4rem;
+  padding: pxToRem(16) pxToRem(24);
+  height: pxToRem(54);
   font-size: 18px;
-  line-height: 2.5rem;
-  min-width: 5.4rem;
+  line-height: pxToRem(25);
+  min-width: pxToRem(54);
 
   &_only_icon {
-    padding: 1.6rem 0.6rem !important;
+    padding: pxToRem(16) pxToRem(6) !important;
   }
 }
 
 .n-button-mid {
-  padding: 1.2rem 1.6rem; // 1.2rem 1.2rem;
-  height: 4.8rem;
+  padding: pxToRem(12) pxToRem(16);
+  height: pxToRem(48);
   font-size: 15px;
-  line-height: 2.5rem;
-  min-width: 4.8rem;
+  line-height: pxToRem(25);
+  min-width: pxToRem(48);
 
   &_only_icon {
-    padding: 1.2rem 1.2rem !important;
+    padding: pxToRem(12) !important;
   }
 }
 
 .n-button-small {
-  padding: 0.4rem 1.6rem; //0.4rem 0.4rem;
-  height: 3rem;
-  font-size: $BaseFontSize + 2;
-  line-height: 1.9rem;
-  min-width: 3rem;
+  padding: pxToRem(4) pxToRem(16);
+  height: pxToRem(30);
+  font-size: pxToRem(12);
+  line-height: pxToRem(19);
+  min-width: pxToRem(30);
 
   &_only_icon {
-    padding: 0.4rem 0.4rem !important;
+    padding: pxToRem(4) !important;
   }
 }
 
@@ -266,22 +266,22 @@
   display: flex;
   justify-content: center;
   height: 100%;
-  width: 2.4rem;
+  width: pxToRem(24);
   object-fit: contain;
-  margin-left: 0.4rem;
+  margin-left: pxToRem(4);
 }
 
 .n-btn-social-icon {
   // position: absolute;
   // left: -3.2rem;
-  font-size: 2.4rem;
+  font-size: pxToRem(24);
   display: flex;
   justify-content: center;
   align-items: center;
 
   @media screen and (max-width: 425px) {
-    height: 2.6rem;
-    width: 2.6rem;
+    height: pxToRem(26);
+    width: pxToRem(26);
   }
 }
 
@@ -304,18 +304,18 @@
 }
 
 .n-icon-small {
-  height: 2rem;
-  font-size: 2rem;
+  height: pxToRem(20);
+  font-size: pxToRem(20);
 }
 
 .n-icon {
-  height: 2.4rem;
-  font-size: 2.4rem;
+  height: pxToRem(24);
+  font-size: pxToRem(24);
 }
 
 .n-icon-large {
-  height: 3rem;
-  font-size: 3rem;
+  height: pxToRem(30);
+  font-size: pxToRem(30);
 }
 
 .disable-click {
@@ -330,8 +330,8 @@
   display: flex;
   align-items: center;
   justify-content: space-evenly;
-  grid-gap: 1.6rem;
-  padding: 1.6rem;
+  grid-gap: pxToRem(16);
+  padding: pxToRem(16);
 
   @media screen and (max-width: 425px) {
     flex-direction: column;

--- a/src/components/Card/Card.scss
+++ b/src/components/Card/Card.scss
@@ -18,16 +18,16 @@
     margin: 0;
     font-weight: bold;
     line-height: 1;
-    font-size: 2.4rem;
+    font-size: pxToRem(24);
     letter-spacing: -1.2px;
     color: inherit;
   }
 
   .n-text-body {
-    margin-top: 0.4rem;
+    margin-top: pxToRem(4);
     font-weight: 500;
     text-transform: none;
-    font-size: 1.6rem;
+    font-size: pxToRem(16);
     letter-spacing: -0.08px;
     line-height: 1.5;
   }
@@ -111,7 +111,7 @@
 .n-heading {
   font-weight: 900;
   text-transform: none;
-  font-size: 2rem;
+  font-size: pxToRem(20);
   letter-spacing: -0.72px;
   line-height: 1.1666666667;
 }
@@ -119,7 +119,7 @@
 .n-text-md {
   font-weight: 500;
   text-transform: none;
-  font-size: 1.6rem;
+  font-size: pxToRem(16);
   letter-spacing: -0.08px;
   line-height: 1.5;
   margin-top: $SpacingXs;
@@ -130,8 +130,8 @@
   justify-content: inherit;
   flex-wrap: wrap;
   align-items: center;
-  margin-top: 1.5rem;
-  gap: 0.5rem;
+  margin-top: pxToRem(15);
+  gap: pxToRem(5);
 }
 
 @media screen and (max-width: 768px) {

--- a/src/components/Checkbox/Checkbox.scss
+++ b/src/components/Checkbox/Checkbox.scss
@@ -2,10 +2,10 @@
 
 .n-checkbox-container {
   position: relative;
-  padding-left: 3rem;
+  padding-left: pxToRem(30);
   cursor: pointer;
-  font-size: 1.5rem;
-  line-height: 1.5rem;
+  font-size: pxToRem(15);
+  line-height: pxToRem(15);
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -15,13 +15,13 @@
   font-weight: 400;
   display: flex;
   align-items: center;
-  padding: 0.45rem 0.45rem 0.45rem 3.2rem;
+  padding: pxToRem(4.5) pxToRem(4.5) pxToRem(4.5) pxToRem(32);
   justify-content: center;
-  gap: 0.8rem;
+  gap: pxToRem(8);
   box-sizing: border-box;
 
   @media screen and (max-width: 768px) {
-    font-size: 1.2rem;
+    font-size: pxToRem(12);
   }
 
   &:hover {
@@ -43,11 +43,11 @@
   position: absolute;
   top: 0;
   left: 0;
-  height: 2.2rem;
-  width: 2.2rem;
+  height: pxToRem(22);
+  width: pxToRem(22);
   background-color: $WhiteColor;
-  border: 1px solid $ColorPrimaryGrey80;
-  border-radius: 0.3rem;
+  border: pxToRem(1) solid $ColorPrimaryGrey80;
+  border-radius: pxToRem(3);
   transition: $TransitionsEaseQuick $TransitionsDurationRapid;
 
   &:hover {
@@ -55,10 +55,10 @@
   }
 
   @media screen and (max-width: 768px) {
-    height: 1.2rem;
-    width: 1.2rem;
-    top: 0.5rem;
-    left: 1rem;
+    height: pxToRem(12);
+    width: pxToRem(12);
+    top: pxToRem(5);
+    left: pxToRem(10);
   }
 }
 
@@ -90,12 +90,12 @@
 
 /* Style the nitrozen-checkbox/indicator */
 .n-checkbox-container .n-checkbox:after {
-  left: 0.8rem;
-  top: 0.35rem;
-  width: 0.4rem;
-  height: 1rem;
-  border: 0.1rem solid $WhiteColor;
-  border-width: 0 0.2rem 0.2rem 0;
+  left: pxToRem(8);
+  top: pxToRem(3.5);
+  width: pxToRem(4);
+  height: pxToRem(10);
+  border: pxToRem(1) solid $WhiteColor;
+  border-width: 0 pxToRem(2) pxToRem(2) 0;
   -webkit-transform: rotate(45deg);
   -ms-transform: rotate(45deg);
   transform: rotate(45deg);
@@ -103,10 +103,10 @@
   transition: all 0.2s ease;
 
   @media screen and (max-width: 768px) {
-    width: 0.2rem;
-    height: 0.5rem;
-    left: 0.4rem;
-    top: 0.17rem;
+    width: pxToRem(2);
+    height: pxToRem(5);
+    left: pxToRem(4);
+    top: pxToRem(1.7);
   }
 }
 .n-checkbox-indeterminate:after {
@@ -121,7 +121,7 @@ input[type="checkbox"]:disabled + .n-checkbox {
   pointer-events: none;
 
   &::after {
-    border-width: 0 0.2rem 0.2rem 0;
+    border-width: 0 pxToRem(2) pxToRem(2) 0;
   }
 }
 
@@ -135,12 +135,12 @@ input[type="checkbox"]:disabled + .n-checkbox {
 
 .n-checkbox-validation {
   position: absolute;
-  top: 3rem;
+  top: pxToRem(30);
   left: 0;
   width: max-content;
   @media screen and (max-width: 768px) {
-    top: 2.5rem;
-    left: 1rem;
+    top: pxToRem(25);
+    left: pxToRem(10);
   }
 }
 
@@ -191,15 +191,15 @@ input[type="checkbox"]:disabled + .n-checkbox {
 
 .social-icon {
   position: absolute;
-  left: -3.2rem;
-  font-size: 2.4rem;
+  left: pxToRem(-32);
+  font-size: pxToRem(24);
   display: flex;
   justify-content: center;
   align-items: center;
   @media screen and (max-width: 768px) {
-    height: 1.6rem;
-    width: 1.6rem;
-    top: 0.5rem;
-    left: -1rem;
+    height: pxToRem(16);
+    width: pxToRem(16);
+    top: pxToRem(5);
+    left: pxToRem(-10);
   }
 }

--- a/src/components/Chip/Chip.scss
+++ b/src/components/Chip/Chip.scss
@@ -24,7 +24,7 @@
 
   .n-chip-label {
     font-size: pxToRem(16);
-    letter-spacing: pxToRem(-0.05);
+    letter-spacing: -0.005em;
     color: $ColorPrimaryGrey80;
   }
 

--- a/src/components/Chip/Chip.scss
+++ b/src/components/Chip/Chip.scss
@@ -3,12 +3,12 @@
 .n-chip {
   background-color: $WhiteColor;
   @include d-flex-center;
-  padding: 0.8rem;
+  padding: pxToRem(8);
   cursor: default;
-  border-radius: 0.4rem;
-  border: 0.1rem solid $ColorPrimaryGrey60;
+  border-radius: pxToRem(4);
+  border: pxToRem(1) solid $ColorPrimaryGrey60;
   color: $TypographyPrimaryColor;
-  font-size: 1.6rem;
+  font-size: pxToRem(16);
   vertical-align: middle;
   white-space: nowrap;
   font-family: $PrimaryFont;
@@ -23,8 +23,8 @@
   }
 
   .n-chip-label {
-    font-size: 1.6rem;
-    letter-spacing: -0.005em;
+    font-size: pxToRem(16);
+    letter-spacing: pxToRem(-0.05);
     color: $ColorPrimaryGrey80;
   }
 
@@ -33,7 +33,7 @@
   }
 
   &:focus {
-    border: 0.4rem solid $ActiveFieldBorder;
+    border: pxToRem(4) solid $ActiveFieldBorder;
   }
 
   &:hover {
@@ -65,12 +65,12 @@
   }
 
   &.rounded {
-    border-radius: 3.9rem;
+    border-radius: pxToRem(39);
   }
 
   .n-icon {
     @include d-flex-center;
-    margin-left: 0.4rem;
+    margin-left: pxToRem(4);
   }
 }
 
@@ -81,8 +81,8 @@
 //DEMO
 .chip-demo-section {
   display: flex;
-  gap: 1rem;
+  gap: pxToRem(10);
   flex-wrap: wrap;
   justify-content: center;
-  max-width: 50rem;
+  max-width: pxToRem(500);
 }

--- a/src/components/Code/Code.scss
+++ b/src/components/Code/Code.scss
@@ -5,20 +5,20 @@
   display: flex;
   width: 100%;
   justify-content: space-between;
-  gap: 1rem;
+  gap: pxToRem(10);
 }
 
 .n-code-input-field {
-  border: 2px solid $ColorPrimaryGrey60;
+  border: pxToRem(2) solid $ColorPrimaryGrey60;
   background: none;
   -webkit-appearance: none;
   display: block;
   -webkit-tap-highlight-color: transparent;
   outline: none;
   text-align: center;
-  border-radius: 1.6rem;
-  height: 4.8rem;
-  width: 4.8rem;
+  border-radius: pxToRem(16);
+  height: pxToRem(48);
+  width: pxToRem(48);
 
   &:focus,
   &:hover {
@@ -26,9 +26,9 @@
   }
 
   @media screen and (max-width: 425px) {
-    height: 3rem;
-    width: 3rem;
-    border-radius: 1rem;
+    height: pxToRem(30);
+    width: pxToRem(30);
+    border-radius: pxToRem(10);
   }
 }
 
@@ -38,15 +38,15 @@
 }
 
 .n-code-input-border-success {
-  border: 2px solid $ColorFeedbackSuccess50;
+  border: pxToRem(2) solid $ColorFeedbackSuccess50;
 }
 
 .n-code-input-border-warning {
-  border: 2px solid $ColorFeedbackWarning50;
+  border: pxToRem(2) solid $ColorFeedbackWarning50;
 }
 
 .n-code-input-border-error {
-  border: 2px solid $ColorFeedbackError50;
+  border: pxToRem(2) solid $ColorFeedbackError50;
 }
 
 .n-code-label {
@@ -55,7 +55,7 @@
   &-container {
     display: flex;
     font-weight: 400;
-    font-size: 1.4rem;
+    font-size: pxToRem(14);
     line-height: 1.4375em;
     letter-spacing: 0.00938em;
     padding: 0px;
@@ -64,11 +64,11 @@
     overflow: hidden;
     text-overflow: ellipsis;
     max-width: 100%;
-    margin: 0 0 4px 4px;
+    margin: 0px 0px pxToRem(4) pxToRem(4);
     color: $TypographyPrimaryColor;
   }
 }
 
 .n-code-underinfo {
-  margin: 0.4rem;
+  margin: pxToRem(4);
 }

--- a/src/components/DateInput/DateInput.scss
+++ b/src/components/DateInput/DateInput.scss
@@ -14,16 +14,16 @@
 
   &-inputfield {
     width: 100%;
-    border: 1px solid $ColorPrimaryGrey60;
-    border-radius: 16px;
-    height: 4.8rem;
+    border: pxToRem(1) solid $ColorPrimaryGrey60;
+    border-radius: pxToRem(16);
+    height: pxToRem(48);
     display: flex;
     align-items: center;
     justify-content: space-between;
     cursor: pointer;
 
     &:hover {
-      border: 1px solid $ColorPrimary60;
+      border: pxToRem(1) solid $ColorPrimary60;
     }
 
     &:active {
@@ -35,7 +35,7 @@
     height: 100%;
     display: flex;
     align-items: center;
-    padding-left: 1.2rem;
+    padding-left: pxToRem(12);
     flex-direction: row;
     width: 80%;
   }
@@ -43,7 +43,7 @@
   &-input-group {
     width: 80%;
     display: flex;
-    padding-left: 1.2rem;
+    padding-left: pxToRem(12);
     align-items: center;
 
     @media screen and (max-width: 425px) {
@@ -56,7 +56,7 @@
     border: 0px;
     -webkit-tap-highlight-color: transparent;
     outline: none;
-    font-size: 1.6rem;
+    font-size: pxToRem(16);
     background: transparent;
 
     &:last-of-type {
@@ -65,7 +65,7 @@
   }
 
   &-divider {
-    font-size: 1.6rem;
+    font-size: pxToRem(16);
 
     &:last-child {
       display: none;
@@ -74,7 +74,7 @@
 
   &-range-field {
     color: $ColorPrimaryGrey60;
-    font-size: 1.6rem;
+    font-size: pxToRem(16);
     width: 90%;
     justify-content: space-between;
     display: flex;
@@ -83,8 +83,8 @@
 }
 
 .n-icon-container {
-  height: 2.4rem;
-  width: 2.4rem;
+  height: pxToRem(24);
+  width: pxToRem(24);
 
   svg {
     height: 100%;
@@ -94,10 +94,10 @@
 
 .n-input-close-btn {
   height: 100%;
-  padding-right: 1.2rem;
+  padding-right: pxToRem(12);
   display: flex;
   align-items: center;
-  width: 2.4rem;
+  width: pxToRem(24);
 }
 
 .n-date-error {
@@ -117,14 +117,14 @@
 }
 
 .n-date-single-field::placeholder {
-  font-size: 1.4rem;
+  font-size: pxToRem(14);
   padding: 0;
 }
 
 .date-input-wrapper {
-  width: 37.6rem;
+  width: pxToRem(376);
   @media screen and (max-width: 425px) {
-    width: 30.6rem;
+    width: pxToRem(306);
   }
 }
 
@@ -139,8 +139,8 @@
 }
 
 .state-date {
-  font-size: 1.4rem;
+  font-size: pxToRem(14);
   text-align: left;
-  width: 37.6rem;
-  margin-bottom: 1.2rem;
+  width: pxToRem(376);
+  margin-bottom: pxToRem(12);
 }

--- a/src/components/DatePicker/DatePicker.scss
+++ b/src/components/DatePicker/DatePicker.scss
@@ -13,8 +13,8 @@
 
   &-calendar-group {
     display: flex;
-    gap: 1.2rem;
-    height: 48.4rem;
+    gap: pxToRem(12);
+    height: pxToRem(484);
     @media screen and (max-width: 425px) {
       display: block;
       height: unset;
@@ -23,22 +23,22 @@
   }
 
   &-divider {
-    border-left: 0.1rem solid $ColorPrimaryGrey40;
+    border-left: pxToRem(1) solid $ColorPrimaryGrey40;
   }
 
   &-wrapper {
     position: absolute;
     background: $WhiteColor;
     box-shadow: $ShadowM;
-    border-radius: 2.4rem;
-    padding: 1.6rem;
+    border-radius: pxToRem(24);
+    padding: pxToRem(16);
     z-index: $ZIndex3;
     @media screen and (max-width: 425px) {
       position: fixed;
       top: 0;
       left: 0;
-      width: calc(100% - 3.2rem);
-      height: calc(100% - 3.2rem);
+      width: calc(100% - pxToRem(32));
+      height: calc(100% - pxToRem(32));
       overflow-y: scroll;
       display: flex;
       flex-direction: column;
@@ -47,8 +47,8 @@
   }
 
   &-wrapper-width {
-    width: calc(100% - 3.2rem);
-    max-width: 38.4rem;
+    width: calc(100% - pxToRem(32));
+    max-width: pxToRem(384);
 
     @media screen and (max-width: 425px) {
       height: 100vh;
@@ -61,21 +61,21 @@
     width: 100%;
     justify-content: center;
     align-items: center;
-    gap: 3.2rem;
-    margin-top: 2.2rem;
+    gap: pxToRem(32);
+    margin-top: pxToRem(22);
   }
 
   &-btn {
-    width: 10.2rem;
-    height: 4.8rem;
-    border: 0.1rem solid $ColorPrimaryGrey40;
+    width: pxToRem(102);
+    height: pxToRem(48);
+    border: pxToRem(1) solid $ColorPrimaryGrey40;
     color: $ColorPrimary60;
     border-radius: 50%;
     display: flex;
-    font-size: 1.6rem;
+    font-size: pxToRem(16);
     align-items: center;
     justify-content: space-around;
-    border-radius: 100rem;
+    border-radius: pxToRem(1000);
     cursor: pointer;
 
     span {
@@ -95,7 +95,7 @@
 
   &-month-year {
     display: flex;
-    gap: 1.2rem;
+    gap: pxToRem(12);
   }
 
   &-toggle-icon {
@@ -105,24 +105,24 @@
     cursor: pointer;
 
     svg {
-      height: 2.4rem;
-      width: 2.4rem;
+      height: pxToRem(24);
+      width: pxToRem(24);
       color: $ColorPrimary60;
     }
   }
 
   &-day-row {
     color: $TypographyPrimaryColor;
-    font-size: 1.6rem;
+    font-size: pxToRem(16);
     display: flex;
     width: 100%;
     align-items: center;
     justify-content: space-between;
-    padding: 2.4rem 0;
+    padding: pxToRem(24) 0;
     position: relative;
 
     span {
-      width: 4.8rem;
+      width: pxToRem(48);
       text-align: center;
     }
   }
@@ -130,23 +130,27 @@
   &-calendar-grid {
     width: 100%;
     display: grid;
-    grid-template-columns: 4.8rem 4.8rem 4.8rem 4.8rem 4.8rem 4.8rem 4.8rem;
+    grid-template-columns: pxToRem(48) pxToRem(48) pxToRem(48) pxToRem(48) pxToRem(
+        48
+      ) pxToRem(48) pxToRem(48);
     justify-content: space-between;
     height: auto;
 
     @media screen and (max-width: 425px) {
-      grid-template-columns: 4.4rem 4.4rem 4.4rem 4.4rem 4.4rem 4.4rem 4.4rem;
+      grid-template-columns: pxToRem(44) pxToRem(44) pxToRem(44) pxToRem(44) pxToRem(
+          44
+        ) pxToRem(44) pxToRem(44);
     }
   }
 
   &-calendar-griditem {
-    font-size: 1.6rem;
+    font-size: pxToRem(16);
     color: $ColorPrimary60;
-    width: 4.8rem;
-    height: 4.8rem;
+    width: pxToRem(48);
+    height: pxToRem(48);
     text-align: center;
     cursor: default;
-    padding-bottom: 0.8rem;
+    padding-bottom: pxToRem(8);
     cursor: pointer;
 
     div {
@@ -165,7 +169,7 @@
       color: $ColorPrimary60;
       opacity: 50%;
       cursor: not-allowed;
-      border-radius: 100rem;
+      border-radius: pxToRem(1000);
     }
 
     &-rangestart {
@@ -192,18 +196,18 @@
     &-selected {
       background-color: $ColorPrimary50;
       color: $WhiteColor;
-      border-radius: 100rem;
+      border-radius: pxToRem(1000);
     }
 
     &-hover {
       &:hover {
         background-color: $ColorPrimaryGrey20;
-        border-radius: 100rem;
+        border-radius: pxToRem(1000);
       }
     }
 
     &-today {
-      border-radius: 100rem;
+      border-radius: pxToRem(1000);
       background-color: $ColorPrimary20;
     }
   }
@@ -215,40 +219,40 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    border-top: 0.1rem solid $ColorPrimaryGrey40;
-    padding-top: 0.8rem;
+    border-top: pxToRem(1) solid $ColorPrimaryGrey40;
+    padding-top: pxToRem(8);
 
     &-width {
-      width: calc(100% - 3.2rem);
-      height: calc(100% - 15rem);
+      width: calc(100% - pxToRem(32));
+      height: calc(100% - pxToRem(150));
       top: 24%;
       @media screen and (max-width: 425px) {
         width: calc(100%);
-        height: calc(100% - 1rem);
+        height: calc(100% - pxToRem(10));
         top: 22%;
       }
     }
 
     &-semiwidth {
-      width: calc(50% - 2.8rem);
-      height: calc(100% - 22rem);
+      width: calc(50% - pxToRem(28));
+      height: calc(100% - pxToRem(220));
       top: 20%;
       @media screen and (max-width: 425px) {
         width: 100%;
-        height: calc(100% - 50rem);
+        height: calc(100% - pxToRem(500));
         top: 10%;
       }
     }
 
     &-item {
       color: $ColorPrimary60;
-      font-size: 1.8rem;
-      padding: 1.2rem;
+      font-size: pxToRem(18);
+      padding: pxToRem(12);
       cursor: pointer;
       display: flex;
       align-items: center;
       justify-content: center;
-      border-radius: 25rem;
+      border-radius: pxToRem(250);
     }
 
     &-selected {
@@ -261,11 +265,11 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    border-top: 0.1rem solid $ColorPrimaryGrey40;
-    padding-top: 1.2rem;
+    border-top: pxToRem(1) solid $ColorPrimaryGrey40;
+    padding-top: pxToRem(12);
     &-date-group {
       display: flex;
-      gap: 2.4rem;
+      gap: pxToRem(24);
       justify-content: space-between;
       align-items: center;
     }
@@ -276,12 +280,12 @@
       align-items: flex-start;
 
       span {
-        font-size: 1.4rem;
+        font-size: pxToRem(14);
         color: $ColorPrimaryGrey80;
 
         &:last-child {
           color: $ColorPrimaryGrey100;
-          font-size: 1.6rem;
+          font-size: pxToRem(16);
         }
       }
     }
@@ -292,17 +296,17 @@
       display: flex;
       flex-direction: column;
       align-items: center;
-      width: calc(100% - 3.2rem);
-      border-top: 1px solid $ColorPrimaryGrey40;
+      width: calc(100% - pxToRem(32));
+      border-top: pxToRem(1) solid $ColorPrimaryGrey40;
       position: absolute;
       bottom: 0;
     }
     &-date-item {
-      font-size: 1.6rem;
+      font-size: pxToRem(16);
       color: $TypographyPrimaryColor;
-      line-height: 2.4rem;
+      line-height: pxToRem(24);
       font-weight: 700;
-      padding: 2.4rem 0;
+      padding: pxToRem(24) 0;
       width: 100%;
     }
     &-button {
@@ -323,8 +327,8 @@
   cursor: pointer;
 
   svg {
-    height: 2.4rem;
-    width: 2.4rem;
+    height: pxToRem(24);
+    width: pxToRem(24);
     color: $ColorPrimary60;
   }
 }

--- a/src/components/Dialog/Dialog.scss
+++ b/src/components/Dialog/Dialog.scss
@@ -6,7 +6,7 @@
   height: 100%;
   top: 0;
   left: 0;
-  backdrop-filter: blur(0.8rem);
+  backdrop-filter: blur(pxToRem(8));
   background-color: $BgColor;
   z-index: 70;
 
@@ -20,9 +20,9 @@
     box-sizing: border-box;
     font-family: $PrimaryFont;
     background: $WhiteColor;
-    border: 0.1rem solid $SecondaryDisabledColor;
-    border-radius: 2.5rem;
-    padding: 2.5rem;
+    border: pxToRem(1) solid $SecondaryDisabledColor;
+    border-radius: pxToRem(25);
+    padding: pxToRem(25);
 
     .n-closebtn-container {
       display: flex;
@@ -52,17 +52,17 @@
   }
 
   .n-dialog-header {
-    margin: 0.6rem 0 0.6rem 0;
+    margin: pxToRem(6) 0 pxToRem(6) 0;
     justify-content: space-between;
     font-weight: 900;
     text-transform: none;
-    font-size: 1.5rem;
+    font-size: pxToRem(15);
     letter-spacing: -0.72px;
     line-height: 1.1666666667;
 
     .n-inline-svg {
-      width: 1.4rem;
-      height: 1.4rem;
+      width: pxToRem(14);
+      height: pxToRem(14);
       cursor: pointer;
     }
   }
@@ -72,17 +72,17 @@
     flex-direction: column;
 
     .n-dialog-footer-btn-spacing {
-      margin-bottom: 0.8rem;
+      margin-bottom: pxToRem(8);
     }
   }
 
   .n-dialog-footer {
-    margin: 2.4rem 0 0;
+    margin: pxToRem(24) 0 0;
     justify-content: flex-end;
     width: 100%;
 
     .n-dialog-footer-btn-spacing {
-      right: 1rem;
+      right: pxToRem(10);
     }
 
     .n-dialog-negative-button {
@@ -91,7 +91,7 @@
 
     .n-dialog-footer-button-margin {
       width: 100%;
-      margin: 1rem;
+      margin: pxToRem(10);
       max-width: 60%;
       margin-bottom: 0;
 
@@ -108,8 +108,8 @@
   .n-dialog-body {
     position: relative;
     font-weight: 400;
-    font-size: 1.5rem;
-    line-height: 2rem;
+    font-size: pxToRem(15);
+    line-height: pxToRem(20);
     letter-spacing: -0.005em;
     word-break: break-word;
     color: $ColorPrimaryGrey80;
@@ -133,8 +133,8 @@
 }
 
 .n-dialog-icon {
-  height: 5rem;
-  width: 5rem;
+  height: pxToRem(50);
+  width: pxToRem(50);
 }
 
 .n-dialog-footer-container {
@@ -156,9 +156,9 @@
   font-weight: 700;
   color: #141414;
   text-transform: none;
-  font-size: 2rem;
+  font-size: pxToRem(20);
   letter-spacing: -0.005em;
-  line-height: 2.5rem;
+  line-height: pxToRem(25);
   font-family: $PrimaryFont;
 }
 .acknowlegdement-header {
@@ -166,12 +166,12 @@
   text-align: center;
 }
 
-@media screen and (max-width: 61.9375rem) {
+@media screen and (max-width: pxToRem(619.375)) {
   .n-wrapper-width-s {
-    width: 46.4rem;
+    width: pxToRem(464);
   }
 
   .n-wrapper-width-m {
-    width: 46.4rem;
+    width: pxToRem(464);
   }
 }

--- a/src/components/Dropdown/Dropdown.scss
+++ b/src/components/Dropdown/Dropdown.scss
@@ -28,18 +28,18 @@
 
   .n-select__trigger {
     color: $TypographyPrimaryColor;
-    font-size: 1.4rem;
-    line-height: 2.2rem;
-    min-height: 2.2rem;
-    padding: 12px;
+    font-size: pxToRem(14);
+    line-height: pxToRem(22);
+    min-height: pxToRem(22);
+    padding: pxToRem(12);
     position: relative;
     display: flex;
     align-items: center;
     justify-content: space-between;
     background: $WhiteColor;
     cursor: pointer;
-    border: 1px solid $ColorSparkleGrey60;
-    border-radius: 16px;
+    border: pxToRem(1) solid $ColorSparkleGrey60;
+    border-radius: pxToRem(16);
 
     span {
       overflow: hidden;
@@ -62,18 +62,18 @@
   .n-options {
     position: absolute;
     display: block;
-    transform: translate3d(0rem, 4.2rem, 0rem);
+    transform: translate3d(0rem, pxToRem(42), 0rem);
     left: 0;
     right: 0;
-    top: 18px;
-    border: 0.1rem solid $SecondaryDisabledColor;
-    border-radius: 0.3rem;
-    box-shadow: 0 0.4rem 0.8rem 0 rgba(229, 229, 229, 0.2),
-      0 0.6rem 2rem 0 rgba(229, 229, 229, 0.19);
+    top: pxToRem(18);
+    border: pxToRem(1) solid $SecondaryDisabledColor;
+    border-radius: pxToRem(3);
+    box-shadow: 0 pxToRem(4) pxToRem(8) 0 rgba(229, 229, 229, 0.2),
+      0 pxToRem(6) pxToRem(20) 0 rgba(229, 229, 229, 0.19);
     background: #fff;
     transition: all 0.5s;
     opacity: 0;
-    max-height: 20rem;
+    max-height: pxToRem(200);
     overflow-y: auto;
     visibility: hidden;
     pointer-events: none;
@@ -88,8 +88,8 @@
   }
 
   .n-dropup {
-    transform: translate3d(0rem, -4.2rem, 0rem);
-    bottom: 1.8rem;
+    transform: translate3d(0rem, pxToRem(-42), 0rem);
+    bottom: pxToRem(18);
     top: unset;
     z-index: $ZIndex2;
   }
@@ -97,21 +97,21 @@
   .n-option {
     position: relative;
     display: block;
-    font-size: 1.4rem;
+    font-size: pxToRem(14);
     color: $TypographyPrimaryColor;
-    line-height: 2.2rem;
+    line-height: pxToRem(22);
     font-weight: 500;
     cursor: pointer;
     transition: all 0.5s;
-    border-bottom: 1px solid $ColorPrimaryGrey40;
+    border-bottom: pxToRem(1) solid $ColorPrimaryGrey40;
 
     .n-checkbox-container {
       pointer-events: none;
 
       .n-checkbox {
         @media screen and (max-width: 768px) {
-          margin-top: 0.4rem;
-          top: 0.2rem !important;
+          margin-top: pxToRem(4);
+          top: pxToRem(2) !important;
           left: 0 !important;
         }
       }
@@ -119,24 +119,24 @@
 
     &.n-option-group-label {
       pointer-events: none;
-      font-size: 1.4rem;
+      font-size: pxToRem(14);
       font-weight: 600;
     }
 
     .n-option-container {
-      padding: 1.4rem;
+      padding: pxToRem(14);
     }
 
     .n-option-child-label {
-      padding-left: 2.4rem;
+      padding-left: pxToRem(24);
       display: flex;
       align-items: center;
     }
 
     .n-option-logo {
-      height: 2.4rem;
+      height: pxToRem(24);
       width: auto;
-      padding-right: 0.8rem;
+      padding-right: pxToRem(8);
     }
 
     .n-option-image {
@@ -178,9 +178,9 @@
 
   .n-dropdown-arrow {
     position: relative;
-    top: -0.4rem;
-    height: 1.5rem;
-    width: 1.5rem;
+    top: pxToRem(-4);
+    height: pxToRem(15);
+    width: pxToRem(15);
   }
 
   .n-dropdown-arrow::after {
@@ -190,7 +190,7 @@
   }
 
   .n-dropdown-open .n-dropdown-arrow {
-    left: 0.5rem;
+    left: pxToRem(5);
     right: 0rem;
     transform: rotate(180deg);
     top: 0rem;
@@ -202,9 +202,9 @@
   font-family: $PrimaryFont;
   font-size: pxToRem(14);
   font-weight: 500;
-  line-height: 2.1rem;
+  line-height: pxToRem(21);
   display: flex;
-  margin-left: 14px;
+  margin-left: pxToRem(14);
 }
 
 .n-dropdown-empty {
@@ -213,13 +213,13 @@
   word-break: break-all;
 
   .n-add-btn {
-    width: 2.5rem;
-    height: 2.5rem;
+    width: pxToRem(25);
+    height: pxToRem(25);
   }
 
   p {
     margin: 0rem;
-    margin-left: 1rem;
+    margin-left: pxToRem(10);
   }
 }
 
@@ -231,7 +231,7 @@
     border: none;
     color: $TypographyPrimaryColor;
     background-color: transparent;
-    font-size: 1.4rem;
+    font-size: pxToRem(14);
   }
   input:focus,
   textarea:focus {
@@ -240,29 +240,29 @@
 }
 
 .horizantal-divider {
-  // height: 0.1rem;
+  // height: pxToRem(1);
   width: 100%;
   background-color: lightgrey;
-  margin: 0.5rem 0;
+  margin: pxToRem(5) 0;
 }
 
 ::-webkit-input-placeholder {
   /* Edge */
   color: $PlaceholderColor;
-  font-size: 1.4rem;
+  font-size: pxToRem(14);
   font-family: $PrimaryFont;
 }
 
 :-ms-input-placeholder {
   /* Internet Explorer 10-11 */
   color: $PlaceholderColor;
-  font-size: 1.4rem;
+  font-size: pxToRem(14);
   font-family: $PrimaryFont;
 }
 
 ::placeholder {
   color: $PlaceholderColor;
-  font-size: 1.4rem;
+  font-size: pxToRem(14);
   font-family: $PrimaryFont;
 }
 
@@ -289,19 +289,19 @@
 }
 
 .n-default-border {
-  border: 2px solid $WhiteColor;
-  border-radius: 20px;
+  border: pxToRem(2) solid $WhiteColor;
+  border-radius: pxToRem(20);
 }
 
 .n-white-border {
-  border: 2px solid $WhiteColor;
+  border: pxToRem(2) solid $WhiteColor;
 }
 
 .n-dropdown-tooltip {
-  margin-left: 0.4rem;
+  margin-left: pxToRem(4);
   .nitrozen-svg-icon {
-    height: 2rem;
-    width: 2rem;
+    height: pxToRem(20);
+    width: pxToRem(20);
   }
 }
 
@@ -317,16 +317,16 @@
 
 .n-dropdown-helper,
 .n-dropdown-validation {
-  margin-left: 1.2rem;
+  margin-left: pxToRem(12);
 }
 
 .n-no-data-container {
-  border-bottom: 1px solid $ColorPrimaryGrey40;
+  border-bottom: pxToRem(1) solid $ColorPrimaryGrey40;
 }
 
 .n-dropdown-prefix {
-  height: 2.4rem;
-  width: 2.4rem;
+  height: pxToRem(24);
+  width: pxToRem(24);
 
   &-icon-wrapper {
     display: flex;
@@ -338,17 +338,17 @@
   width: 100%;
   align-items: center;
   justify-content: space-between;
-  padding: 0 2px;
+  padding: 0 pxToRem(2);
 }
 
 .n-option-wrapper {
   display: flex;
   flex-direction: column;
   color: $ColorPrimaryGrey100;
-  font-size: 1.6rem;
+  font-size: pxToRem(16);
 }
 
 .n-option-subtext {
-  font-size: 1.2rem;
+  font-size: pxToRem(12);
   color: $TypographyPrimaryColor;
 }

--- a/src/components/Dropdown/Dropdown.scss
+++ b/src/components/Dropdown/Dropdown.scss
@@ -50,7 +50,7 @@
     input[type="search"]::-webkit-search-cancel-button {
       position: relative;
       right: 0;
-      font-size: $BaseFontSize + 6;
+      font-size: pxToRem(16);
       cursor: pointer;
     }
 
@@ -78,7 +78,7 @@
     visibility: hidden;
     pointer-events: none;
     z-index: $ZIndex1;
-    border-radius: $BaseFontSize + 6px;
+    border-radius: pxToRem(16);
   }
 
   .n-select.n-dropdown-open .n-options {
@@ -200,7 +200,7 @@
 .n-dropdown-label {
   color: $TypographyPrimaryColor;
   font-family: $PrimaryFont;
-  font-size: $BaseFontSize + 4px;
+  font-size: pxToRem(14);
   font-weight: 500;
   line-height: 2.1rem;
   display: flex;

--- a/src/components/Grid/Grid.scss
+++ b/src/components/Grid/Grid.scss
@@ -3,13 +3,13 @@
 .n-grid-container {
   width: 100%;
   display: grid;
-  gap: 1.5rem;
+  gap: pxToRem(15);
   overflow: hidden;
 }
 
 @media screen and (max-width: 768px) {
   .n-grid-container {
-    gap: 1rem;
+    gap: pxToRem(10);
     -ms-overflow-style: none; /* Internet Explorer 10+ */
     scrollbar-width: none; /* Firefox */
   }
@@ -19,7 +19,7 @@
 
   .overflow {
     overflow: scroll;
-    gap: 0.75rem;
+    gap: pxToRem(7.5);
   }
   .overflow > * {
     grid-row: 1;
@@ -30,8 +30,8 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  font-size: 2rem;
+  font-size: pxToRem(20);
   color: $TypographyPrimaryColor;
   background-color: rgb(187, 208, 226);
-  padding: 1rem;
+  padding: pxToRem(10);
 }

--- a/src/components/Icons/Icons.scss
+++ b/src/components/Icons/Icons.scss
@@ -4,16 +4,16 @@
 .svg-category-container {
   display: flex;
   flex-direction: column;
-  margin-bottom: 4rem;
-  border: 0.08rem solid $Whisper;
-  padding: 2.6rem 1.2rem;
+  margin-bottom: pxToRem(40);
+  border: pxToRem(0.8) solid $Whisper;
+  padding: pxToRem(26) pxToRem(12);
   background: $Snow;
-  border-radius: 0.6rem;
+  border-radius: pxToRem(6);
 }
 
 .storybook-svg-container {
   margin-inline: auto;
-  max-width: 70rem;
+  max-width: pxToRem(700);
   min-height: 70vh;
   @include d-flex-center;
 }
@@ -23,7 +23,7 @@
   text-transform: capitalize;
   color: $TypographyPrimaryColor;
   font-weight: 600;
-  margin-bottom: 2.4rem;
+  margin-bottom: pxToRem(24);
   text-align: center;
 }
 
@@ -31,23 +31,23 @@
   width: 100%;
   @include d-flex-center;
   flex-direction: column;
-  padding-bottom: 3.6rem;
-  border-radius: 0.6rem;
+  padding-bottom: pxToRem(36);
+  border-radius: pxToRem(6);
   background: linear-gradient(90deg, $Spray, $PurpleTaupe);
   font-family: $PrimaryFont;
 
   h1 {
     font-size: pxToRem(32);
-    margin-block: 2.6rem;
+    margin-block: pxToRem(26);
     color: $WhiteColor;
     text-align: center;
   }
 
   img {
-    max-width: 52rem;
+    max-width: pxToRem(520);
     width: 95%;
     display: block;
-    border-radius: 0.6rem;
+    border-radius: pxToRem(6);
   }
 
   .demo-description {
@@ -56,15 +56,15 @@
     display: flex;
     align-items: center;
     font-size: pxToRem(15);
-    gap: 0.4rem;
-    margin-top: 2rem;
+    gap: pxToRem(4);
+    margin-top: pxToRem(20);
   }
 }
 
 .filters-section {
-  padding-block: 2.6rem;
+  padding-block: pxToRem(26);
   display: flex;
-  gap: 2rem;
+  gap: pxToRem(20);
   background: linear-gradient(to bottom, $WhiteColor 90%, transparent);
   z-index: $ZIndex1;
   position: sticky;
@@ -82,15 +82,15 @@
   .filters-cta {
     display: flex;
     align-items: center;
-    padding-inline: 2rem;
+    padding-inline: pxToRem(20);
     font-size: $PrimaryFont + 3;
     cursor: pointer;
     border: none;
-    border-radius: 0.6rem;
-    gap: 0.6rem;
+    border-radius: pxToRem(6);
+    gap: pxToRem(6);
     font-weight: 600;
     color: $TypographySecondaryColor;
-    border: 0.2rem solid transparent;
+    border: pxToRem(2) solid transparent;
     transition: 0.1s ease;
 
     &:active {
@@ -104,23 +104,23 @@
   display: flex;
   justify-content: center;
   flex-wrap: wrap;
-  gap: 1.6rem;
+  gap: pxToRem(16);
 }
 
 .svg-btn {
   background: white;
-  border: 0.1rem solid $Whisper;
-  padding: 2rem 0.6rem 3rem 0.6rem;
+  border: pxToRem(0.1) solid $Whisper;
+  padding: pxToRem(20) pxToRem(6) pxToRem(30) pxToRem(6);
   box-shadow: none;
-  border-radius: 0.6rem;
+  border-radius: pxToRem(6);
   transition: 0.1s ease;
   cursor: pointer;
   display: flex;
   flex-direction: column;
   font-size: pxToRem(10);
   align-items: center;
-  gap: 1.2rem;
-  width: 10rem;
+  gap: pxToRem(12);
+  width: pxToRem(100);
   position: relative;
   overflow: hidden;
   font-family: $PrimaryFont;
@@ -132,10 +132,10 @@
     left: 0;
     right: 0;
     background: $TypographyTertiaryColor;
-    padding-block: 0.2rem;
+    padding-block: pxToRem(2);
     display: flex;
     align-items: center;
-    gap: 0.4rem;
+    gap: pxToRem(4);
     justify-content: center;
     transition: 0.1s ease;
     font-weight: 600;
@@ -164,7 +164,7 @@
     white-space: nowrap;
     overflow-x: hidden;
     text-overflow: ellipsis;
-    max-width: 8rem;
+    max-width: pxToRem(80);
     font-size: pxToRem(10);
   }
 
@@ -172,14 +172,14 @@
     position: absolute;
     top: 0;
     right: 0;
-    font-size: 1.4rem;
+    font-size: pxToRem(14);
     border: none;
-    border-radius: 0.6rem;
+    border-radius: pxToRem(6);
     border-top-left-radius: 0;
     border-bottom-right-radius: 0;
     cursor: pointer;
     background: none;
-    padding: 0.8rem;
+    padding: pxToRem(8);
     transition: 0.2s ease;
     opacity: 0;
     @include d-flex-center;
@@ -191,7 +191,7 @@
   }
 
   &:hover {
-    box-shadow: 0rem 0rem 0.2rem $Spray;
+    box-shadow: 0rem 0rem pxToRem(2) $Spray;
 
     .svg-edit-cta {
       opacity: 0.5;

--- a/src/components/Icons/Icons.scss
+++ b/src/components/Icons/Icons.scss
@@ -18,7 +18,7 @@
   @include d-flex-center;
 }
 .category-heading {
-  font-size: $BaseFontSize + 14;
+  font-size: pxToRem(24);
   font-family: $PrimaryFont;
   text-transform: capitalize;
   color: $TypographyPrimaryColor;
@@ -37,7 +37,7 @@
   font-family: $PrimaryFont;
 
   h1 {
-    font-size: $BaseFontSize + 22;
+    font-size: pxToRem(32);
     margin-block: 2.6rem;
     color: $WhiteColor;
     text-align: center;
@@ -55,7 +55,7 @@
     text-align: left;
     display: flex;
     align-items: center;
-    font-size: $BaseFontSize + 5;
+    font-size: pxToRem(15);
     gap: 0.4rem;
     margin-top: 2rem;
   }
@@ -75,7 +75,7 @@
 
     input,
     input::-webkit-input-placeholder {
-      font-size: $BaseFontSize + 4;
+      font-size: pxToRem(14);
     }
   }
 
@@ -117,7 +117,7 @@
   cursor: pointer;
   display: flex;
   flex-direction: column;
-  font-size: $BaseFontSize;
+  font-size: pxToRem(10);
   align-items: center;
   gap: 1.2rem;
   width: 10rem;
@@ -139,7 +139,7 @@
     justify-content: center;
     transition: 0.1s ease;
     font-weight: 600;
-    font-size: $BaseFontSize + 1;
+    font-size: pxToRem(11);
 
     * {
       color: $WhiteColor;
@@ -165,7 +165,7 @@
     overflow-x: hidden;
     text-overflow: ellipsis;
     max-width: 8rem;
-    font-size: $BaseFontSize;
+    font-size: pxToRem(10);
   }
 
   .svg-edit-cta {

--- a/src/components/Input/Input.scss
+++ b/src/components/Input/Input.scss
@@ -10,35 +10,35 @@
   position: relative;
   outline: none;
   box-sizing: border-box;
-  font-size: 1.6rem;
+  font-size: pxToRem(16);
   -webkit-appearance: none;
   display: block;
   -webkit-tap-highlight-color: transparent;
 }
 
 .input-prefixed {
-  margin-left: 3rem;
-  width: calc(100% - 30px);
+  margin-left: pxToRem(30);
+  width: calc(100% - pxToRem(30));
 }
 
 .input-suffixed {
-  width: calc(100% - 30px);
+  width: calc(100% - pxToRem(30));
 }
 
 .input-contained {
-  margin-left: 3rem;
-  width: calc(100% - 60px);
+  margin-left: pxToRem(30);
+  width: calc(100% - pxToRem(60));
 }
 
 .n-input-container {
   width: inherit;
-  padding: 1.2rem;
-  border: 0.2rem solid $ColorSparkleGrey60;
-  border-radius: 1.6rem;
+  padding: pxToRem(12);
+  border: pxToRem(2) solid $ColorSparkleGrey60;
+  border-radius: pxToRem(16);
   display: flex;
 
   &:hover {
-    border: 0.2rem solid $ColorPrimary60;
+    border: pxToRem(2) solid $ColorPrimary60;
   }
 }
 
@@ -58,7 +58,7 @@
   padding: 0px;
   // transform-origin: left top;
   max-width: 100%;
-  margin-left: 1.2rem;
+  margin-left: pxToRem(12);
 }
 
 .n-input-label-default {
@@ -66,13 +66,13 @@
 }
 
 .n-input-label-prefixed {
-  left: 3rem;
+  left: pxToRem(30);
 }
 
 .n-input-textarea {
-  height: 9.6rem;
-  line-height: 2.1rem;
-  padding-top: 0.6rem;
+  height: pxToRem(96);
+  line-height: pxToRem(21);
+  padding-top: pxToRem(6);
 }
 
 .n-input:disabled {
@@ -101,9 +101,9 @@
 .n-input-label {
   color: $LabelColor;
   font-family: $PrimaryFont;
-  font-size: 1.4rem;
+  font-size: pxToRem(14);
   font-weight: 500;
-  line-height: 2.1rem;
+  line-height: pxToRem(21);
   display: flex;
   flex: 1;
   p {
@@ -119,10 +119,10 @@
   display: flex;
   justify-content: flex-end;
   position: relative;
-  font-size: 1.4rem;
+  font-size: pxToRem(14);
   color: $TypographyPrimaryColor;
   opacity: 0.4;
-  margin-right: 1.2rem;
+  margin-right: pxToRem(12);
 }
 
 .n-input-grp:focus-within + .n-input-label-container > .n-input-label {
@@ -132,27 +132,27 @@
 ::-webkit-input-placeholder {
   /* Edge */
   color: $PlaceholderColor;
-  font-size: 1.6rem;
+  font-size: pxToRem(16);
   font-family: $PrimaryFont;
 }
 
 :-ms-input-placeholder {
   /* Internet Explorer 10-11 */
   color: $PlaceholderColor;
-  font-size: 1.6rem;
+  font-size: pxToRem(16);
   font-family: $PrimaryFont;
 }
 
 ::placeholder {
   color: $PlaceholderColor;
-  font-size: 1.6rem;
+  font-size: pxToRem(16);
   font-family: $PrimaryFont;
 }
 
 input[type="search"]::-webkit-search-cancel-button {
   position: relative;
-  right: 1rem;
-  font-size: 1.4rem;
+  right: pxToRem(10);
+  font-size: pxToRem(14);
   cursor: pointer;
 }
 
@@ -161,7 +161,7 @@ input[type="search"]::-webkit-search-cancel-button {
   position: absolute;
   // left: 0;
   // top: 0;
-  left: 1rem;
+  left: pxToRem(10);
   top: 25%;
 }
 
@@ -173,10 +173,10 @@ input[type="search"]::-webkit-search-cancel-button {
 .n-input-prefix,
 .n-input-suffix {
   height: 100%;
-  width: 2.2rem;
+  width: pxToRem(22);
   margin: auto;
   box-sizing: border-box;
-  border-radius: 0.3rem;
+  border-radius: pxToRem(3);
   background: none;
   position: absolute;
 
@@ -192,7 +192,7 @@ input[type="search"]::-webkit-search-cancel-button {
 
 .n-suffix-position {
   top: 0;
-  right: 1rem;
+  right: pxToRem(10);
 }
 
 .n-remove-left-border {
@@ -231,7 +231,7 @@ textarea {
 }
 
 .search-icon {
-  font-size: 2.4rem;
+  font-size: pxToRem(24);
   color: $Gray;
 }
 
@@ -239,19 +239,19 @@ textarea {
   color: $PrimaryGrey80;
   position: relative;
   // margin-top: calc($SpacingXs + 1px);
-  margin-left: 1.2rem;
+  margin-left: pxToRem(12);
 }
 
 .n-helper-text {
   display: block;
   font-weight: 500;
   text-transform: none;
-  font-size: 1.4rem;
+  font-size: pxToRem(14);
   letter-spacing: -0.07px;
   line-height: 1.4285714286;
   word-wrap: break-word;
   color: $TypographyPrimaryColor;
-  margin-top: 0.4rem;
+  margin-top: pxToRem(4);
 }
 
 .n-field-error {
@@ -267,15 +267,15 @@ textarea {
 }
 
 .n-error-border::after {
-  border-bottom: 0.2rem solid $ColorFeedbackError50;
+  border-bottom: pxToRem(2) solid $ColorFeedbackError50;
 }
 
 .n-warning-border::after {
-  border-bottom: 0.2rem solid $ColorFeedbackWarning50;
+  border-bottom: pxToRem(2) solid $ColorFeedbackWarning50;
 }
 
 .n-success-border::after {
-  border-bottom: 0.2rem solid $ColorFeedbackSuccess50;
+  border-bottom: pxToRem(2) solid $ColorFeedbackSuccess50;
 }
 
 .n-password-eye {
@@ -288,17 +288,17 @@ textarea {
 }
 
 .n-input-tooltip {
-  margin-left: 0.5rem;
+  margin-left: pxToRem(5);
 
   .nitrozen-svg-icon {
-    height: 2rem;
-    width: 2rem;
+    height: pxToRem(20);
+    width: pxToRem(20);
   }
 }
 
 .n-focused-border {
-  border: 0.2rem solid $ColorPrimary60 !important;
-  border-radius: 1.6rem;
+  border: pxToRem(2) solid $ColorPrimary60 !important;
+  border-radius: pxToRem(16);
 }
 
 .n-input:hover::placeholder {

--- a/src/components/Menu/Menu.scss
+++ b/src/components/Menu/Menu.scss
@@ -47,7 +47,7 @@
     }
   }
   svg {
-    font-size: calc($BaseFontSize + 10px);
+    font-size: pxToRem(21);
     color: $ColorPrimary60;
   }
 }

--- a/src/components/Menu/Menu.scss
+++ b/src/components/Menu/Menu.scss
@@ -1,7 +1,7 @@
 @import "./../../base/base.scss";
 
 .menu-story-container {
-  height: 250px;
+  height: pxToRem(250);
   display: flex;
   justify-content: space-evenly;
   align-items: center;
@@ -22,18 +22,18 @@
   transition: all 0.4s ease-in;
   &-close {
     transition: all 0s ease-in;
-    max-height: 0px;
+    max-height: pxToRem(0);
   }
   &-open {
-    max-height: 1000px;
+    max-height: pxToRem(1000);
   }
 }
 .n-menu-block-toggle {
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 30px;
-  width: 30px;
+  height: pxToRem(30);
+  width: pxToRem(30);
   border-radius: 50%;
   background-color: $ColorSecondaryGrey20;
   transform: rotateZ(0deg);

--- a/src/components/MenuItem/MenuItem.scss
+++ b/src/components/MenuItem/MenuItem.scss
@@ -7,7 +7,7 @@
     cursor: pointer;
     list-style: none;
     text-decoration: none;
-    font-size: calc($BaseFontSize + 6px);
+    font-size: pxToRem(16);
     min-width: 100px;
     font-weight: 400;
     color: $TypographyPrimaryColor;
@@ -37,7 +37,7 @@
     color: $ColorPrimaryGrey60;
   }
   &-heading > a {
-    font-size: calc($BaseFontSize + 4px);
+    font-size: pxToRem(14);
     &:hover {
       background-color: $ColorPrimaryBackground;
     }

--- a/src/components/MenuItem/MenuItem.scss
+++ b/src/components/MenuItem/MenuItem.scss
@@ -8,13 +8,13 @@
     list-style: none;
     text-decoration: none;
     font-size: pxToRem(16);
-    min-width: 100px;
+    min-width: pxToRem(100);
     font-weight: 400;
     color: $TypographyPrimaryColor;
     background-color: $ColorPrimaryBackground;
     padding: $SpacingBase;
     box-sizing: border-box;
-    height: 40px;
+    height: pxToRem(40);
     display: flex;
     justify-content: flex-start;
     align-items: center;
@@ -23,7 +23,7 @@
     }
   }
   &-divider {
-    border-bottom: 1px solid $ColorSecondaryGrey40;
+    border-bottom: pxToRem(1) solid $ColorSecondaryGrey40;
   }
   &-selected > a {
     color: $ColorPrimary60;

--- a/src/components/Nudge/Nudge.scss
+++ b/src/components/Nudge/Nudge.scss
@@ -14,17 +14,17 @@
     display: flex;
     flex-direction: column;
     background-color: $ColorSecondaryGrey80;
-    border-radius: 2.4rem;
-    width: 38.4rem;
-    padding: 1.6rem;
-    margin-bottom: 1rem;
+    border-radius: pxToRem(24);
+    width: pxToRem(384);
+    padding: pxToRem(16);
+    margin-bottom: pxToRem(10);
 
     @media screen and (max-width: 768px) {
-      width: 34.4rem;
+      width: pxToRem(344);
     }
 
     @media screen and (max-width: 425px) {
-      width: 32.8rem;
+      width: pxToRem(328);
     }
   }
 
@@ -42,50 +42,50 @@
   &-text-wrapper {
     display: flex;
     flex-direction: column;
-    margin-left: 1rem;
-    gap: 0.4rem;
+    margin-left: pxToRem(10);
+    gap: pxToRem(4);
   }
 
   &-header {
     color: $WhiteColor;
-    font-size: 1.6rem;
+    font-size: pxToRem(16);
     font-weight: 700;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    max-width: 30rem;
+    max-width: pxToRem(300);
     user-select: none;
   }
 
   &-support {
     color: $WhiteColor;
     font-weight: 500;
-    font-size: 1.4rem;
+    font-size: pxToRem(14);
     user-select: none;
   }
 
   &-image-container {
-    height: 4rem;
-    width: 4rem;
+    height: pxToRem(40);
+    width: pxToRem(40);
     object-fit: contain;
-    border-radius: 0.6rem;
+    border-radius: pxToRem(6);
 
     img {
       height: 100%;
       width: 100%;
-      border-radius: 0.4rem;
+      border-radius: pxToRem(4);
     }
   }
 
   &-bottom {
     display: flex;
     justify-content: flex-end;
-    gap: 1.2rem;
-    margin-top: 1.6rem;
+    gap: pxToRem(12);
+    margin-top: pxToRem(16);
 
     .n-nudge-cta1 {
       background-color: transparent;
-      font-size: 1.6rem;
+      font-size: pxToRem(16);
       font-weight: 700;
 
       &:hover {
@@ -98,9 +98,9 @@
     }
 
     .n-nudge-cta2 {
-      border: 1px solid $ColorPrimaryGrey60;
+      border: pxToRem(1) solid $ColorPrimaryGrey60;
       background-color: transparent;
-      font-size: 1.6rem;
+      font-size: pxToRem(16);
       font-weight: 700;
 
       &:hover {
@@ -115,8 +115,8 @@
 }
 
 .n-nudge-top-right {
-  top: 5rem;
-  right: 5rem;
+  top: pxToRem(50);
+  right: pxToRem(50);
   transition: transform 0.6s cubic-bezier(0.4, 0, 0.2, 1);
   animation: nudge-in-right 0.7s;
   @media screen and (max-width: 425px) {

--- a/src/components/Pagination/Pagination.scss
+++ b/src/components/Pagination/Pagination.scss
@@ -3,19 +3,19 @@
 .n-pagination-container {
   font-family: $PrimaryFont;
   color: $TypographyPrimaryColor;
-  border: 1px solid $ColorPrimaryGrey60;
-  border-radius: 1.2rem;
-  padding: 1.2rem;
+  border: pxToRem(1) solid $ColorPrimaryGrey60;
+  border-radius: pxToRem(12);
+  padding: pxToRem(12);
 
   .n-pagination {
     display: flex;
-    font-size: 1.4rem;
+    font-size: pxToRem(14);
     color: $LabelColor;
-    font-size: 1.4rem;
+    font-size: pxToRem(14);
     font-weight: 400;
     align-items: center;
     flex-wrap: wrap;
-    gap: 1.2rem;
+    gap: pxToRem(12);
     .n-pagination__left {
       flex: 1;
       display: flex;
@@ -27,10 +27,10 @@
       .n-pagination__count {
         color: $ColorPrimaryGrey80;
         font-weight: 500;
-        font-size: 1.4rem;
-        line-height: 2rem;
+        font-size: pxToRem(14);
+        line-height: pxToRem(20);
         @media only screen and (max-width: $sm-min) {
-          font-size: 1.2rem;
+          font-size: pxToRem(12);
         }
       }
     }
@@ -44,52 +44,52 @@
       display: flex;
       justify-content: center;
       align-items: center;
-      gap: 2rem;
+      gap: pxToRem(20);
       flex-wrap: wrap;
       @media only screen and (max-width: $sm-min) {
-        gap: 1.8rem;
+        gap: pxToRem(18);
         width: 100%;
       }
       .n-pagination__number {
         display: flex;
-        gap: 0.8rem;
+        gap: pxToRem(8);
         flex-direction: row;
         position: relative;
         flex-wrap: wrap;
         @media only screen and (max-width: $sm-min) {
-          gap: 0.5rem;
+          gap: pxToRem(5);
         }
       }
       .n-pagination__showpopup {
         position: absolute;
-        padding: 1.2rem;
+        padding: pxToRem(12);
         z-index: 1;
         background: $ColorPrimaryBackground;
-        box-shadow: 0px 4px 16px rgb(0 0 0 / 8%);
-        border-radius: 1.6rem;
-        width: 18.5rem;
+        box-shadow: 0px pxToRem(4) pxToRem(16) rgb(0 0 0 / 8%);
+        border-radius: pxToRem(16);
+        width: pxToRem(185);
         height: auto;
         display: flex;
         flex-direction: column;
-        gap: 0.8rem;
-        bottom: 6rem;
+        gap: pxToRem(8);
+        bottom: pxToRem(6);
         .n-pagination__search_input {
-          border: 1px solid $ColorPrimaryGrey60;
-          border-radius: 1.2rem;
-          padding: 1rem;
+          border: pxToRem(1) solid $ColorPrimaryGrey60;
+          border-radius: pxToRem(12);
+          padding: pxToRem(10);
           display: flex;
           justify-content: center;
           align-items: center;
-          gap: 0.8rem;
+          gap: pxToRem(8);
           input::placeholder {
             font-weight: 500;
-            font-size: 1.4rem;
-            line-height: 2rem;
+            font-size: pxToRem(14);
+            line-height: pxToRem(20);
             letter-spacing: -0.005em;
             color: $ColorPrimaryGrey80;
           }
           .n-pagination__search_logo {
-            padding-top: 0.5rem;
+            padding-top: pxToRem(5);
           }
           .n-input {
             border: 0px;
@@ -99,17 +99,17 @@
             position: relative;
             outline: none;
             box-sizing: border-box;
-            font-size: 1.6rem;
+            font-size: pxToRem(16);
             -webkit-appearance: none;
             display: block;
             -webkit-tap-highlight-color: transparent;
           }
         }
         ::-webkit-scrollbar {
-          width: 0.25rem;
-          border-radius: 0px 0px 48px 48px;
-          left: 0.25rem;
-          top: 0.25rem;
+          width: pxToRem(2.5);
+          border-radius: 0px 0px pxToRem(48) pxToRem(48);
+          left: pxToRem(2.5);
+          top: pxToRem(2.5);
         }
         ::-webkit-scrollbar-track {
           background: $ColorPrimaryBackground;
@@ -126,18 +126,18 @@
           grid-template-rows: repeat(4, 1fr);
           flex-wrap: wrap;
           overflow: auto;
-          height: 10.5rem;
+          height: pxToRem(105);
           .n-pagination__search_number_inactive {
-            height: 4rem;
-            width: 4rem;
+            height: pxToRem(40);
+            width: pxToRem(40);
             display: flex;
             justify-content: center;
             align-items: center;
             border-radius: 50%;
             flex: 1 0 21%;
             font-weight: 700;
-            font-size: 1.6rem;
-            line-height: 2.4rem;
+            font-size: pxToRem(16);
+            line-height: pxToRem(24);
             color: $ColorPrimaryGrey60;
             cursor: pointer;
           }
@@ -147,32 +147,32 @@
         }
       }
       .n-pagination__popup_left {
-        right: 20rem;
+        right: pxToRem(200);
         @media only screen and (max-width: $sm-min) {
-          right: 10rem;
+          right: pxToRem(100);
         }
       }
       .n-pagination__popup_right {
-        left: 20rem;
+        left: pxToRem(200);
         @media only screen and (max-width: $sm-min) {
-          left: 10rem;
+          left: pxToRem(100);
         }
       }
       .n-pagination__number_inactive {
-        height: 3.2rem;
-        width: 3.2rem;
+        height: pxToRem(32);
+        width: pxToRem(32);
         display: flex;
         justify-content: center;
         align-items: center;
         border-radius: 50%;
         color: $ColorPrimaryGrey60;
         font-weight: 700;
-        font-size: 1.6rem;
-        line-height: 2.4rem;
+        font-size: pxToRem(16);
+        line-height: pxToRem(24);
         cursor: pointer;
         @media only screen and (max-width: $sm-min) {
-          height: 3.2rem;
-          width: 3.2rem;
+          height: pxToRem(32);
+          width: pxToRem(32);
         }
       }
       .n-pagination__number_active {
@@ -190,20 +190,20 @@
       flex: 1;
       justify-content: flex-end;
       align-items: center;
-      gap: 0.8rem;
+      gap: pxToRem(8);
 
       .n-pagination__select {
         display: flex;
         align-items: center;
-        border: 1px solid $ColorPrimaryGrey60;
-        border-radius: 1.2rem;
+        border: pxToRem(1) solid $ColorPrimaryGrey60;
+        border-radius: pxToRem(12);
         position: relative;
         .n-pagination__select__label {
           font-weight: 400;
-          font-size: 1.2rem;
-          line-height: 1.6rem;
+          font-size: pxToRem(12);
+          line-height: pxToRem(16);
           color: $ColorPrimaryGrey80;
-          padding-left: 1.2rem;
+          padding-left: pxToRem(12);
         }
         .n-pagination-page-size .n-select-wrapper {
           position: unset;
@@ -212,12 +212,12 @@
           position: unset;
         }
         .n-pagination-page-size .n-select-wrapper .n-options {
-          bottom: 1rem;
+          bottom: pxToRem(10);
           top: auto;
         }
         .n-pagination-page-size .n-select-wrapper .n-select__trigger {
           border: 0;
-          padding: 0.8rem;
+          padding: pxToRem(8);
           background: $ColorPrimaryBackground;
           color: var(--TypographyPrimaryColor, $ColorPrimaryGrey80);
         }
@@ -228,8 +228,8 @@
         }
 
         .n-pagination-page-size {
-          width: 7.2rem;
-          margin: 0 1.2rem;
+          width: pxToRem(72);
+          margin: 0 pxToRem(12);
         }
       }
     }
@@ -241,23 +241,23 @@
   align-items: center;
   flex-wrap: nowrap;
   width: max-content;
-  gap: 0.8rem;
+  gap: pxToRem(8);
 
   .n-pagination__select {
     .n-select-wrapper .n-select__trigger {
       background: $ColorPrimaryBackground;
       color: var(--TypographyPrimaryColor, $ColorPrimaryGrey80);
-      border: 0.1rem solid var(--ColorSparkleGrey60, #e0e0e0);
+      border: pxToRem(1) solid var(--ColorSparkleGrey60, #e0e0e0);
       .n-dropdown-input-arrow-wrapper {
-        gap: 1.124rem;
+        gap: pxToRem(11.24);
       }
     }
   }
 
   .n-pagination__count {
     font-weight: 500;
-    font-size: 1.4rem;
-    line-height: 2rem;
+    font-size: pxToRem(14);
+    line-height: pxToRem(20);
     letter-spacing: -0.005em;
     color: rgba(0, 0, 0, 0.65);
     white-space: nowrap;
@@ -267,9 +267,9 @@
 
   .n-pagination__prev,
   .n-pagination__next {
-    width: 3.2rem;
-    height: 3.2rem;
-    min-width: 3.2rem;
+    width: pxToRem(32);
+    height: pxToRem(32);
+    min-width: pxToRem(32);
     border: unset;
     background-color: #fff;
 
@@ -284,17 +284,17 @@
     justify-content: flex-start;
     align-items: center;
     flex-wrap: nowrap;
-    gap: 0.4rem;
+    gap: pxToRem(4);
 
     .n-input-container {
       background-color: #fff;
-      border: 0.1rem solid var(--ColorSparkleGrey60, #e0e0e0);
+      border: pxToRem(1) solid var(--ColorSparkleGrey60, #e0e0e0);
       .n-input {
         text-align: center;
         min-width: 2.5ch;
         width: 2.5ch;
         max-width: 6.5ch;
-        height: 2.2rem;
+        height: pxToRem(22);
       }
     }
   }
@@ -303,21 +303,21 @@
   .n-pagination__select {
     .n-select__trigger {
       min-height: unset;
-      height: 1.4rem;
+      height: pxToRem(14);
     }
   }
   .n-pagination__main {
     .n-input-container {
       .n-input {
-        height: 1.4rem;
+        height: pxToRem(14);
       }
     }
   }
 }
 .n-pagination__prev,
 .n-pagination__next {
-  width: 2.4rem;
-  height: 2.4rem;
+  width: pxToRem(24);
+  height: pxToRem(24);
   cursor: pointer;
 
   svg {

--- a/src/components/Radio/Radio.scss
+++ b/src/components/Radio/Radio.scss
@@ -18,7 +18,7 @@
     line-height: 1.5rem;
     color: $ColorPrimaryGrey80;
     font-family: $PrimaryFont;
-    font-size: $BaseFontSize + 5;
+    font-size: pxToRem(15);
     font-weight: 400;
     display: flex;
     height: 100%;

--- a/src/components/Radio/Radio.scss
+++ b/src/components/Radio/Radio.scss
@@ -1,7 +1,7 @@
 @import "./../../base/base.scss";
 
 .n-radio-group {
-  height: 2.1rem;
+  height: pxToRem(21);
   position: relative;
 
   input[type="radio"]:checked,
@@ -13,9 +13,9 @@
   input[type="radio"]:checked + label,
   input[type="radio"]:not(:checked) + label {
     position: relative;
-    padding-left: 3rem;
+    padding-left: pxToRem(30);
     cursor: pointer;
-    line-height: 1.5rem;
+    line-height: pxToRem(15);
     color: $ColorPrimaryGrey80;
     font-family: $PrimaryFont;
     font-size: pxToRem(15);
@@ -36,9 +36,9 @@
     position: absolute;
     left: 0;
     top: 0;
-    width: 2rem;
-    height: 2rem;
-    border: 1px solid $ColorPrimaryGrey80;
+    width: pxToRem(20);
+    height: pxToRem(20);
+    border: pxToRem(1) solid $ColorPrimaryGrey80;
     border-radius: 100%;
     background: $WhiteColor;
     transition: $TransitionsEaseQuick $TransitionsDurationRapid;
@@ -49,7 +49,7 @@
   }
 
   input[type="radio"]:checked + label:before {
-    border: 1px solid $ColorPrimary50;
+    border: pxToRem(1) solid $ColorPrimary50;
     box-shadow: inset 0 0 0 0.375em $ColorPrimary50;
   }
 
@@ -96,19 +96,19 @@
 
 .radio-story {
   box-sizing: border-box;
-  border-radius: 0.4rem;
+  border-radius: pxToRem(4);
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0.8rem;
-  gap: 1rem;
-  width: 14.6rem;
-  height: 4rem;
+  padding: pxToRem(8);
+  gap: pxToRem(10);
+  width: pxToRem(146);
+  height: pxToRem(40);
 }
 
 .n-radio-validation {
   position: absolute;
-  top: 3rem;
+  top: pxToRem(30);
   left: 0;
   width: max-content;
 }
@@ -126,17 +126,17 @@ input[type="radio"]:not(:checked) + label.error-state:hover::before {
 }
 
 input[type="radio"]:checked + label.warning-state:before {
-  border: 1px solid $ColorFeedbackWarning50;
+  border: pxToRem(1) solid $ColorFeedbackWarning50;
   box-shadow: inset 0 0 0 0.375em $ColorFeedbackWarning50;
 }
 
 input[type="radio"]:checked + label.success-state:before {
-  border: 1px solid $ColorFeedbackSuccess50;
+  border: pxToRem(1) solid $ColorFeedbackSuccess50;
   box-shadow: inset 0 0 0 0.375em $ColorFeedbackSuccess50;
 }
 
 input[type="radio"]:checked + label.error-state:before {
-  border: 1px solid $ColorFeedbackError50;
+  border: pxToRem(1) solid $ColorFeedbackError50;
   box-shadow: inset 0 0 0 0.375em $ColorFeedbackError50;
 }
 
@@ -156,12 +156,12 @@ input[type="radio"]:checked + label.error-state:hover::before {
 }
 
 .n-prefix-icon {
-  font-size: 2.4rem;
+  font-size: pxToRem(24);
   justify-content: center;
   align-items: center;
-  margin-right: 1rem;
+  margin-right: pxToRem(10);
   cursor: pointer;
   position: absolute;
   top: 0px;
-  left: -3rem;
+  left: pxToRem(-30);
 }

--- a/src/components/Stepper/Stepper.scss
+++ b/src/components/Stepper/Stepper.scss
@@ -2,7 +2,7 @@
 
 .storybook-stepper-container {
   margin-inline: auto;
-  max-width: 70rem;
+  max-width: pxToRem(700);
   min-height: 70vh;
   @include d-flex-center;
 }
@@ -16,7 +16,7 @@
     display: inline-block;
     position: absolute;
     @include absolute-position-center(rotate(45deg));
-    top: calc(50% - 0.2rem);
+    top: calc(50% - pxToRem(2));
   }
   .stepper-description {
     color: $LabelColor;
@@ -86,26 +86,24 @@
     .n-stepper-container {
       display: flex;
       flex-direction: column;
-      gap: 0.8rem;
-    }
-
-    .n-stepper-group {
-      --circle-size: 3.2rem;
-      --spacing: 0.8rem;
+      gap: pxToRem(8);
     }
 
     .n-circle-outer-container {
       display: grid;
       align-items: center;
-      grid-template-columns: 3.4rem auto;
-      grid-template-rows: auto minmax(2rem, auto);
-      grid-row-gap: 0.8rem;
-      grid-column-gap: 1rem;
+      grid-template-columns: pxToRem(34) auto;
+      grid-template-rows: auto minmax(pxToRem(20), auto);
+      grid-row-gap: pxToRem(8);
+      grid-column-gap: pxToRem(10);
       cursor: pointer;
     }
 
     .n-stepper-group {
-      column-gap: 1.6rem;
+      $circleSize: pxToRem(32);
+      $spacing: pxToRem(8);
+
+      column-gap: pxToRem(16);
 
       &.inactive-stepper {
         opacity: 0.3;
@@ -113,15 +111,15 @@
         filter: saturate(0.1);
       }
       .bar-ball-container {
-        gap: 0.8rem;
+        gap: pxToRem(8);
         flex-direction: column;
         justify-content: center;
       }
       .n-bar {
-        width: 0.1rem;
+        width: pxToRem(1);
         background: $SecondaryDisabledColor;
         min-height: 100%;
-        border-radius: 1rem;
+        border-radius: pxToRem(10);
         justify-self: center;
 
         &.completed-bar {
@@ -179,10 +177,10 @@
         }
       }
       .active-stepper {
-        top: 0.1rem;
-        bottom: 0.1rem;
-        left: 0.1rem;
-        right: 0.1rem;
+        top: pxToRem(1);
+        bottom: pxToRem(1);
+        left: pxToRem(1);
+        right: pxToRem(1);
         background: $Bubbles;
       }
       .n-text {
@@ -191,15 +189,15 @@
       }
       .stepper-description {
         font-size: pxToRem(12);
-        margin-top: 0.4rem;
-        line-height: 1.8rem;
+        margin-top: pxToRem(4);
+        line-height: pxToRem(18);
       }
       .n-circle-outer {
-        height: var(--circle-size);
-        width: var(--circle-size);
+        height: #{$circleSize};
+        width: #{$circleSize};
 
         &.nitrozen-circle-border {
-          border: 0.1rem;
+          border: pxToRem(1);
           border-style: solid;
 
           &.current {
@@ -225,13 +223,13 @@
         }
       }
       .nitrozen-cirle-check-container .n-circle-outer {
-        border: 0.1rem solid $Bubbles;
+        border: pxToRem(1) solid $Bubbles;
       }
       .nitrozen-checkmark {
-        height: 1.4rem;
-        width: 0.6rem;
-        border-bottom: 0.2rem solid $SeaGreen;
-        border-right: 0.2rem solid $SeaGreen;
+        height: pxToRem(14);
+        width: pxToRem(6);
+        border-bottom: pxToRem(2) solid $SeaGreen;
+        border-right: pxToRem(2) solid $SeaGreen;
       }
       .stepper-header-description {
         & .header-description {
@@ -239,21 +237,21 @@
         }
 
         & .heading-center {
-          margin-top: 1.2rem;
+          margin-top: pxToRem(12);
         }
         @media screen and (max-width: 768px) {
           flex-direction: column;
           justify-content: flex-start;
-          gap: 1rem;
+          gap: pxToRem(10);
 
           & .heading-center {
-            margin-top: 0.2rem;
+            margin-top: pxToRem(2);
           }
         }
       }
       .stepper-header-description button {
         align-self: center;
-        min-width: 12rem;
+        min-width: pxToRem(120);
         cursor: pointer;
         @media screen and (max-width: 768px) {
           align-self: flex-start;
@@ -264,9 +262,9 @@
 
   //HORIZONTAL STEPPER
   &.horizontal {
+    $circleSize: pxToRem(32);
+    $spacing: pxToRem(8);
     .n-stepper-group {
-      --circle-size: 3.2rem;
-      --spacing: 0.8rem;
       display: flex;
       flex-grow: 10;
       flex-basis: 100%;
@@ -284,57 +282,57 @@
     .n-stepper-group:not(:last-child):after {
       content: "";
       position: relative;
-      top: 1.6rem;
-      height: 1px;
+      top: pxToRem(16);
+      height: pxToRem(1);
       background-color: #e0e0e0;
       order: -1;
-      width: calc(100% - var(--circle-size) - calc(var(--spacing)));
-      left: calc(50% + calc(var(--circle-size) / 2 + var(--spacing)));
+      width: calc(100% - #{$circleSize} - calc(#{$spacing}));
+      left: calc(50% + calc(#{$circleSize} / 2 + #{$spacing}));
     }
 
     .n-stepper-container {
       display: flex;
-      gap: 0.8rem;
+      gap: pxToRem(8);
     }
     .n-stepper-group {
       flex-direction: column;
       text-align: center;
 
       .n-circle-outer {
-        height: var(--circle-size);
-        width: var(--circle-size);
+        height: #{$circleSize};
+        width: #{$circleSize};
         @include d-flex-center;
         border-radius: 100%;
 
         &.current {
           background: $ColorSparkle50;
           color: $ColorSparkle80;
-          border: 0.1rem solid $ColorSparkle50;
+          border: pxToRem(1) solid $ColorSparkle50;
         }
 
         &.upcoming {
           background: none;
           color: $ColorPrimaryGrey60;
-          border: 0.1rem solid $ColorPrimaryGrey60;
+          border: pxToRem(1) solid $ColorPrimaryGrey60;
         }
 
         &.disabled {
           background: none;
           color: $ColorPrimaryGrey60;
           opacity: 0.3;
-          border: 0.1rem solid $ColorPrimaryGrey60;
+          border: pxToRem(1) solid $ColorPrimaryGrey60;
         }
 
         &.issue {
           background: $ColorSparkle20;
           color: $ColorSparkle60;
-          border: 0.1rem solid $ColorSparkle60;
+          border: pxToRem(1) solid $ColorSparkle60;
         }
 
         &.completed {
           background: $ColorSparkle20;
           color: $ColorSparkle50;
-          border: 0.1rem solid $ColorSparkle50;
+          border: pxToRem(1) solid $ColorSparkle50;
         }
       }
       .nitrozen-circle-inner {
@@ -344,20 +342,20 @@
       }
 
       .stepper-header-description {
-        margin-top: 1rem;
+        margin-top: pxToRem(10);
       }
       .bar-ball-container {
-        gap: 0.8rem;
+        gap: pxToRem(8);
       }
       .nitrozen-checkmark {
-        height: 0.6rem;
-        width: 0.3rem;
-        border-bottom: 0.15rem solid $SuccessColor;
-        border-right: 0.15rem solid $SuccessColor;
+        height: pxToRem(6);
+        width: pxToRem(3);
+        border-bottom: pxToRem(1.5) solid $SuccessColor;
+        border-right: pxToRem(1.5) solid $SuccessColor;
       }
       .n-bar {
         flex-grow: 1;
-        height: 0.1rem;
+        height: pxToRem(1);
       }
       .nitrozen-active {
         background-color: $SuccessColor;
@@ -375,8 +373,8 @@
       }
       .stepper-description {
         font-size: pxToRem(10);
-        line-height: 1.6rem;
-        margin-top: 0.2rem;
+        line-height: pxToRem(16);
+        margin-top: pxToRem(2);
         max-width: 85%;
         word-wrap: break-word;
       }
@@ -390,9 +388,9 @@
 .heading-progress {
   display: flex;
   align-items: center;
-  margin-bottom: 2.6rem;
-  gap: 2rem;
-  line-height: 2.6rem;
+  margin-bottom: pxToRem(26);
+  gap: pxToRem(20);
+  line-height: pxToRem(26);
 
   .stepper-heading {
     display: inline-block;
@@ -408,8 +406,8 @@
   margin-left: auto;
 
   .svg-circle-container {
-    height: 6rem;
-    width: 6rem;
+    height: pxToRem(60);
+    width: pxToRem(60);
     position: relative;
   }
 
@@ -426,8 +424,8 @@
     @include d-flex-center;
   }
   svg {
-    height: 5rem;
-    width: 5rem;
+    height: pxToRem(50);
+    width: pxToRem(50);
     fill: none;
     margin-left: auto;
     display: block;

--- a/src/components/Stepper/Stepper.scss
+++ b/src/components/Stepper/Stepper.scss
@@ -10,7 +10,7 @@
 .n-stepper {
   margin: 0 auto;
   width: 100%;
-  font-size: $BaseFontSize + 6;
+  font-size: pxToRem(16);
 
   .nitrozen-checkmark {
     display: inline-block;
@@ -186,11 +186,11 @@
         background: $Bubbles;
       }
       .n-text {
-        font-size: $BaseFontSize + 4;
+        font-size: pxToRem(14);
         font-weight: 500;
       }
       .stepper-description {
-        font-size: $BaseFontSize + 2;
+        font-size: pxToRem(12);
         margin-top: 0.4rem;
         line-height: 1.8rem;
       }
@@ -370,11 +370,11 @@
         }
       }
       .n-text {
-        font-size: $BaseFontSize + 4;
+        font-size: pxToRem(14);
         font-weight: 500;
       }
       .stepper-description {
-        font-size: $BaseFontSize;
+        font-size: pxToRem(10);
         line-height: 1.6rem;
         margin-top: 0.2rem;
         max-width: 85%;
@@ -399,7 +399,7 @@
     flex-grow: 1;
     font-family: $PrimaryFont;
     font-weight: 600;
-    font-size: $BaseFontSize + 8;
+    font-size: pxToRem(18);
     color: $TypographyPrimaryColor;
   }
 }
@@ -414,7 +414,7 @@
   }
 
   span {
-    font-size: $BaseFontSize + 2;
+    font-size: pxToRem(12);
     font-family: $PrimaryFont;
     color: $TypographyPrimaryColor;
   }

--- a/src/components/Tab/Tab.scss
+++ b/src/components/Tab/Tab.scss
@@ -2,10 +2,10 @@
 
 .n-tab-container {
   display: flex;
-  height: 4.8rem;
+  height: pxToRem(48);
   position: relative;
   &.n-tab-scroll {
-    padding: 0 6.4rem;
+    padding: 0 pxToRem(64);
     overscroll-behavior-x: none;
     .n-tab {
       overflow: hidden;
@@ -71,14 +71,14 @@
     background: none;
     color: $ColorPrimary60;
     border-radius: 50%;
-    height: 4rem;
-    width: 4rem;
+    height: pxToRem(40);
+    width: pxToRem(40);
     display: flex;
     align-items: center;
     justify-content: center;
     position: absolute;
     z-index: 1;
-    font-size: 3rem;
+    font-size: pxToRem(30);
     top: 50%;
     transform: translateY(-50%);
     cursor: pointer;
@@ -88,14 +88,14 @@
     }
 
     &.n-icon-btn-left {
-      left: 0.5rem;
+      left: pxToRem(5);
       display: none;
       svg {
         color: $ActiveFieldBorder;
       }
     }
     &.n-icon-btn-right {
-      right: 0.5rem;
+      right: pxToRem(5);
       display: none;
       svg {
         color: $ActiveFieldBorder;
@@ -110,16 +110,16 @@
     width: 100%;
     box-sizing: border-box;
     list-style: none;
-    margin: 0 1.6rem;
+    margin: 0 pxToRem(16);
     font-family: $PrimaryFont;
     position: relative;
     & .n-d-scroll {
-      height: 0.4rem;
+      height: pxToRem(4);
       background-color: $ColorPrimary50;
       position: absolute;
       bottom: 0;
       left: 0;
-      border-radius: 0.4rem;
+      border-radius: pxToRem(4);
       transition: 0.3s ease all;
     }
     &::-webkit-scrollbar {

--- a/src/components/TabItem/TabItem.scss
+++ b/src/components/TabItem/TabItem.scss
@@ -4,7 +4,7 @@
   display: flex;
   justify-content: center;
   font-family: $PrimaryFont;
-  padding: 1.2rem 0.8rem;
+  padding: pxToRem(12) pxToRem(80);
   flex: 1;
   align-items: center;
   button.n-tab-btn {
@@ -14,11 +14,11 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    font-size: 1.6rem;
-    line-height: 2.4rem;
+    font-size: pxToRem(16);
+    line-height: pxToRem(24);
     color: $ColorPrimaryGrey80;
     font-weight: 500;
-    min-width: 2.5rem;
+    min-width: pxToRem(25);
     height: 100%;
     width: 100%;
     white-space: pre;
@@ -30,14 +30,14 @@
     }
     .n-tab-icon {
       display: inline-flex;
-      margin-right: 0.8rem;
+      margin-right: pxToRem(8);
       align-items: center;
       justify-content: center;
     }
   }
 
   .tab-item-icon {
-    margin-top: 0.15rem;
-    margin-right: 0.4rem;
+    margin-top: pxToRem(1.5);
+    margin-right: pxToRem(4);
   }
 }

--- a/src/components/Table/Table.scss
+++ b/src/components/Table/Table.scss
@@ -13,10 +13,10 @@
   top: 0;
   z-index: 10;
   pointer-events: none;
-  width: 4px;
+  width: pxToRem(4);
   background: #f5f5f5;
-  border-radius: 250px;
-  border: 1px solid #e0e0e0;
+  border-radius: pxToRem(250);
+  border: pxToRem(1) solid #e0e0e0;
 }
 
 .n-main-table {
@@ -49,9 +49,9 @@
   th {
     border-bottom: none;
     background-color: $ColorPrimary50;
-    padding: 16px;
+    padding: pxToRem(16);
     text-align: left;
-    font-size: 16px;
+    font-size: pxToRem(16);
     font-weight: 300;
   }
 
@@ -70,9 +70,9 @@
   td {
     border-radius: 0;
     border-left: $TableBorderWidth solid $ColorSparkleGrey40;
-    padding: 16px;
+    padding: pxToRem(16);
     border-top: $TableBorderWidth solid $ColorSparkleGrey40;
-    font-size: 14px;
+    font-size: pxToRem(14);
     background: #fff;
   }
 
@@ -99,10 +99,10 @@
 
 .n-table-footer {
   td {
-    padding: 16px;
+    padding: pxToRem(16);
     border-left: $TableBorderWidth solid $ColorSparkleGrey40;
     border-top: $TableBorderWidth solid $ColorSparkleGrey40;
-    font-size: 14px;
+    font-size: pxToRem(14);
   }
 
   td:last-child {
@@ -126,7 +126,7 @@
 
 .n-table-header-action {
   cursor: pointer;
-  margin-left: 6px;
+  margin-left: pxToRem(6);
 }
 
 .n-cursor-pointer {
@@ -140,7 +140,7 @@
 }
 
 .n-table-header-text {
-  margin-right: 4px;
+  margin-right: pxToRem(4);
 }
 
 .n-action-icon {
@@ -156,14 +156,14 @@
     padding: 0px;
   }
   .n-checkbox {
-    top: -10px;
+    top: pxToRem(-10);
     @media screen and (max-width: 768px) {
       left: 0;
     }
   }
 }
 .n-table-header-checkbox {
-  width: 10px;
+  width: pxToRem(10);
 }
 .n-table-row-item-checkbox {
   td:first-child {

--- a/src/components/Toast/Toast.scss
+++ b/src/components/Toast/Toast.scss
@@ -13,16 +13,16 @@
     background: $ColorSecondaryGrey80;
     border-radius: 1.4em;
     color: $WhiteColor;
-    width: 25rem;
-    margin-bottom: 1rem;
+    width: pxToRem(250);
+    margin-bottom: pxToRem(10);
     transition: transform 0.6s ease-in-out;
-    min-height: 2.5rem;
+    min-height: pxToRem(25);
     display: flex;
     justify-content: space-between;
-    padding: 1.2rem;
+    padding: pxToRem(12);
     font-family: $PrimaryFont;
     @media screen and (max-width: 425px) {
-      width: 32.8rem !important;
+      width: pxToRem(328) !important;
     }
     .n-toast-left-container {
       display: flex;
@@ -107,15 +107,15 @@
 }
 
 .n-toast-top-right {
-  top: 5rem;
-  right: 5rem;
+  top: pxToRem(50);
+  right: pxToRem(50);
   transition: transform 0.6s ease-in-out;
   animation: toast-in-right 0.7s;
 }
 
 .n-toast-bottom-right {
-  bottom: 5rem;
-  right: 5rem;
+  bottom: pxToRem(50);
+  right: pxToRem(50);
   transition: transform 0.6s ease-in-out;
   animation: toast-in-right 0.7s;
 }
@@ -127,15 +127,15 @@
 }
 
 .n-toast-top-left {
-  top: 5rem;
-  left: 5rem;
+  top: pxToRem(50);
+  left: pxToRem(50);
   transition: transform 0.6s ease-in;
   animation: toast-in-left 0.7s;
 }
 
 .n-toast-bottom-left {
-  bottom: 5rem;
-  left: 5rem;
+  bottom: pxToRem(50);
+  left: pxToRem(50);
   transition: transform 0.6s ease-in;
   animation: toast-in-left 0.7s;
 }

--- a/src/components/Toast/Toast.scss
+++ b/src/components/Toast/Toast.scss
@@ -7,7 +7,7 @@
   z-index: $ZIndex3;
   display: flex;
   flex-direction: column;
-  font-size: $BaseFontSize + 6;
+  font-size: pxToRem(16);
 
   .n-toast-wrapper {
     background: $ColorSecondaryGrey80;

--- a/src/components/ToggleButton/ToggleButton.scss
+++ b/src/components/ToggleButton/ToggleButton.scss
@@ -10,19 +10,19 @@
     display: inline-block;
 
     &.small {
-      height: 2rem;
-      width: 4rem;
+      height: pxToRem(20);
+      width: pxToRem(40);
     }
 
     &.medium {
-      height: 2.4rem;
-      width: 4.8rem;
+      height: pxToRem(24);
+      width: pxToRem(48);
     }
 
     //DEFAULT
     &.large {
-      height: 2.8rem;
-      width: 5.6rem;
+      height: pxToRem(28);
+      width: pxToRem(56);
     }
 
     .n-disabled {
@@ -76,25 +76,25 @@
       -ms-transform: translate(100%, 50%);
       transform: translate(100%, 50%);
       background-color: $ColorPrimaryGrey80;
-      box-shadow: 0 0 0.1rem 0 rgb(0 0 0 / 12%),
-        0 0.1rem 0.1rem 0 rgb(0 0 0 / 24%);
+      box-shadow: 0 0 pxToRem(1) 0 rgb(0 0 0 / 12%),
+        0 pxToRem(1) pxToRem(1) 0 rgb(0 0 0 / 24%);
       -webkit-transition: 0.4s;
       transition: 0.4s;
     }
 
     &.small .slider-ball {
-      height: 1.2rem;
-      width: 1.2rem;
+      height: pxToRem(12);
+      width: pxToRem(12);
     }
 
     &.medium .slider-ball {
-      height: 1.6rem;
-      width: 1.6rem;
+      height: pxToRem(16);
+      width: pxToRem(16);
     }
 
     &.large .slider-ball {
-      height: 2rem;
-      width: 2rem;
+      height: pxToRem(20);
+      width: pxToRem(20);
     }
 
     .n-disable .slider-ball {
@@ -116,7 +116,7 @@
     }
 
     // input:focus+.n-slider {
-    //   box-shadow: 0 0 0.1rem $SecondaryColor;
+    //   box-shadow: 0 0 pxToRem(1) $SecondaryColor;
     // }
 
     .n-slider.checked .slider-ball {
@@ -149,27 +149,27 @@
     }
 
     &.small .label-text {
-      left: 4.5rem;
-      font-size: 1.4rem;
-      padding: 0.18rem;
+      left: pxToRem(45);
+      font-size: pxToRem(14);
+      padding: pxToRem(1.8);
     }
 
     &.medium .label-text {
-      left: 6rem;
-      font-size: 1.6rem;
-      padding: 0.25rem;
+      left: pxToRem(60);
+      font-size: pxToRem(16);
+      padding: pxToRem(2.5);
     }
 
     &.large .label-text {
-      left: 7.5rem;
-      font-size: 2rem;
-      padding: 0.35rem;
+      left: pxToRem(75);
+      font-size: pxToRem(20);
+      padding: pxToRem(3.5);
     }
   }
 }
 
 .n-slider.n-round {
-  border-radius: 3rem;
+  border-radius: pxToRem(30);
 }
 
 .n-round .slider-ball {
@@ -180,22 +180,22 @@
 .all-togglebtn-sections {
   @include d-flex-center;
   align-items: flex-start;
-  gap: 3.4rem;
+  gap: pxToRem(34);
 
   .section,
   .section-validation {
     display: flex;
     flex-direction: column;
-    gap: 2rem;
+    gap: pxToRem(20);
 
     span {
       font-family: $PrimaryFont;
-      font-size: pxToRem(12);
+      font-size: pxToRem(120);
     }
   }
 
   .section-validation {
-    gap: 3.5rem;
+    gap: pxToRem(35);
   }
 }
 
@@ -203,17 +203,17 @@
 .medium .n-toggle-validation,
 .large .n-toggle-validation {
   position: absolute;
-  top: 2.5rem;
+  top: pxToRem(25);
   left: 0;
   width: max-content;
 }
 
 .medium .n-toggle-validation {
-  top: 3rem;
+  top: pxToRem(30);
 }
 
 .large .n-toggle-validation {
-  top: 3.5rem;
+  top: pxToRem(35);
 }
 
 .warning-state {
@@ -305,19 +305,19 @@
 }
 
 .social-icon-small {
-  left: -0.8rem;
-  font-size: 2rem;
+  left: pxToRem(-8);
+  font-size: pxToRem(20);
   display: flex;
 }
 
 .social-icon-medium {
-  left: -1.2rem;
-  font-size: 2.4rem;
+  left: pxToRem(-12);
+  font-size: pxToRem(24);
   display: flex;
 }
 
 .social-icon-large {
-  left: -1.8rem;
-  font-size: 2.8rem;
+  left: pxToRem(-18);
+  font-size: pxToRem(28);
   display: flex;
 }

--- a/src/components/ToggleButton/ToggleButton.scss
+++ b/src/components/ToggleButton/ToggleButton.scss
@@ -190,7 +190,7 @@
 
     span {
       font-family: $PrimaryFont;
-      font-size: $BaseFontSize + 2;
+      font-size: pxToRem(12);
     }
   }
 

--- a/src/components/Tooltip/Tooltip.scss
+++ b/src/components/Tooltip/Tooltip.scss
@@ -4,7 +4,7 @@
   position: relative;
   display: flex;
   cursor: pointer;
-  font-size: $BaseFontSize + 6;
+  font-size: pxToRem(16);
 
   .nitrozen-tooltipcontent {
     visibility: hidden;
@@ -17,7 +17,7 @@
     font-family: $PrimaryFont;
     position: absolute;
     z-index: $ZIndex3;
-    font-size: $BaseFontSize + 2;
+    font-size: pxToRem(12);
 
     .nitrozen-tooltip-link {
       color: $WhiteColor;

--- a/src/components/Tooltip/Tooltip.scss
+++ b/src/components/Tooltip/Tooltip.scss
@@ -10,10 +10,10 @@
     visibility: hidden;
     width: max-content;
     background-color: $EclipseColor;
-    line-height: 2.08rem;
+    line-height: pxToRem(20.8);
     color: $WhiteColor;
-    border-radius: 0.5rem;
-    padding: 1rem;
+    border-radius: pxToRem(5);
+    padding: pxToRem(10);
     font-family: $PrimaryFont;
     position: absolute;
     z-index: $ZIndex3;
@@ -29,7 +29,7 @@
       position: absolute;
       border-style: solid;
       border-color: $EclipseColor transparent transparent transparent;
-      border-width: 0.7rem;
+      border-width: pxToRem(7);
     }
   }
 
@@ -120,13 +120,13 @@
   right: 100%;
   top: 50%;
   transform: translateX(0) translateY(-50%);
-  margin-right: 0.8rem;
+  margin-right: pxToRem(8);
 
   &::after {
     top: 50%;
     left: 100%;
     /* To the left of the tooltip */
-    margin-top: -0.5rem;
+    margin-top: pxToRem(-5);
     transform: rotate(270deg);
   }
 }
@@ -135,13 +135,13 @@
   right: 100%;
   top: 100%;
   transform: translateX(0) translateY(-50%);
-  margin-right: 0.8rem;
+  margin-right: pxToRem(8);
 
   &::after {
     top: 30%;
     left: 100%;
     /* To the left of the tooltip */
-    margin-top: -0.5rem;
+    margin-top: pxToRem(-5);
     transform: rotate(270deg);
   }
 }
@@ -150,13 +150,13 @@
   right: 100%;
   top: 0%;
   transform: translateX(0) translateY(-50%);
-  margin-right: 0.8rem;
+  margin-right: pxToRem(8);
 
   &::after {
     top: 60%;
     left: 100%;
     /* To the left of the tooltip */
-    margin-top: -0.5rem;
+    margin-top: pxToRem(-5);
     transform: rotate(270deg);
   }
 }
@@ -165,13 +165,13 @@
   left: 100%;
   top: 50%;
   transform: translateX(0) translateY(-50%);
-  margin-left: 0.8rem;
+  margin-left: pxToRem(8);
 
   &::after {
     top: 50%;
     right: 100%;
     /* To the right of the tooltip */
-    margin-top: -0.5rem;
+    margin-top: pxToRem(-5);
     transform: rotate(90deg);
   }
 }
@@ -180,13 +180,13 @@
   left: 100%;
   top: 100%;
   transform: translateX(0) translateY(-50%);
-  margin-left: 0.8rem;
+  margin-left: pxToRem(8);
 
   &::after {
     top: 30%;
     right: 100%;
     /* To the right of the tooltip */
-    margin-top: -0.5rem;
+    margin-top: pxToRem(-5);
     transform: rotate(90deg);
   }
 }
@@ -195,13 +195,13 @@
   left: 100%;
   top: 0%;
   transform: translateX(0) translateY(-50%);
-  margin-left: 0.8rem;
+  margin-left: pxToRem(8);
 
   &::after {
     top: 60%;
     right: 100%;
     /* To the right of the tooltip */
-    margin-top: -0.5rem;
+    margin-top: pxToRem(-5);
     transform: rotate(90deg);
   }
 }

--- a/src/components/Validation/Validation.scss
+++ b/src/components/Validation/Validation.scss
@@ -8,7 +8,7 @@
   display: flex;
   font-weight: 500;
   text-transform: none;
-  font-size: $BaseFontSize + 4px;
+  font-size: pxToRem(14);
   letter-spacing: -0.07px;
 
   img {

--- a/src/components/Validation/Validation.scss
+++ b/src/components/Validation/Validation.scss
@@ -1,7 +1,7 @@
 @import "./../Input/Input.scss";
 
 .n-validation-container {
-  margin-top: 8px;
+  margin-top: pxToRem(8);
 }
 
 .n-state-container {
@@ -9,7 +9,7 @@
   font-weight: 500;
   text-transform: none;
   font-size: pxToRem(14);
-  letter-spacing: -0.07px;
+  letter-spacing: pxToRem(-0.07);
 
   img {
     height: 100%;
@@ -18,7 +18,7 @@
 }
 
 .n-svg-container {
-  height: 16px;
-  width: 16px;
-  margin-right: 6px;
+  height: pxToRem(16);
+  width: pxToRem(16);
+  margin-right: pxToRem(6);
 }


### PR DESCRIPTION
Closes #88 

## Problem

Currently, the library assumes a base font size of 10px. As rem is used as the unit for most measurements, changing the base font size will directly impact the dimensions of the components. Typically, 3rd party UI libraries use the default font size of the browser, which is 16px. However, in Nitrogen, we override the default font size, making this library incompatible with other UI libraries and solely dependent on it for all UI components.

## Solution

The solution is achieved using a CSS variable called `BaseFontSize`, which holds an integer value (without the unit). This variable is used to make all other measurements using the following steps..

1. If the user provides a value for the `BaseFontSize` variable, that value will be used for all calculations. Otherwise, a default value of `10` will be used.
<img width="424" alt="image" src="https://github.com/gofynd/nitrozen-react/assets/50210712/d002e5f6-91d7-4efd-858e-bbb6ea6e3aad">
<br>
<br>

2. If the value of the `BaseFontSize` variable is anything other than the default font-size value (i.e. 16), then the user must override the font-size for the app.
<img width="371" alt="image" src="https://github.com/gofynd/nitrozen-react/assets/50210712/ad718f83-a50f-4749-92df-e5e7fc0dca90">
<br>
<br>

3. A function uses the value of BaseFontSize provided to convert px values to rem values

The function: <br>
<img width="556" alt="image" src="https://github.com/gofynd/nitrozen-react/assets/50210712/f5bf1466-5e90-4eae-b786-dd7512351201"><br>
Usage of the above function:
<br>
<img width="335" alt="image" src="https://github.com/gofynd/nitrozen-react/assets/50210712/bf59afcf-9b08-408e-90e8-9315218c1fc8">
<br>
<br>


## Component Screenshots

- ### All themes

#### Before 
![Before](https://github.com/gofynd/nitrozen-react/assets/50210712/22cb8a4e-befc-48b6-b927-5f4483f244c4)

#### After
![After](https://github.com/gofynd/nitrozen-react/assets/50210712/24dfe7b9-01a8-41b0-b56c-2a81575851d6)

- ### Icon Button

#### Before 
![image](https://github.com/gofynd/nitrozen-react/assets/50210712/49abafac-232c-4b17-9f94-f54b52bb2710)

#### After
![image](https://github.com/gofynd/nitrozen-react/assets/50210712/7d857478-ed2f-486f-881f-27bca5a61408)

- ### Button With left Icon

#### Before
![image](https://github.com/gofynd/nitrozen-react/assets/50210712/58448477-879f-4091-aef2-5b1ddf5fd037)

#### After
![image](https://github.com/gofynd/nitrozen-react/assets/50210712/9aa8f226-225a-47d7-a1bb-26271d36bb6c)

