### PR TITLE
fix(toggle): issues in toggle button

### DIFF
--- a/src/components/ToggleButton/ToggleButton.tsx
+++ b/src/components/ToggleButton/ToggleButton.tsx
@@ -7,7 +7,7 @@ import NitrozenValidation from "./../Validation";
 export interface ToggleButtonProps {
   disabled?: boolean;
   onToggle?: Function;
-  value: boolean;
+  value?: boolean;
   className?: string;
   style?: React.CSSProperties;
   size?: string;
@@ -44,9 +44,10 @@ const ToggleButton = (props: ToggleButtonProps) => {
   }, [value]);
 
   const changed = useCallback(() => {
+    onToggle && onToggle(!toggleActive);
+
     setToggle(!toggleActive);
-    onToggle?.();
-  }, [toggleActive]);
+  }, [toggleActive, onToggle]);
 
   const Icon = props.icon as React.ElementType;
   return (


### PR DESCRIPTION
I have faced some issues in the ToggleButton of the Nitrozen React in some of our extensions
Below are the issues and the PR for the same
 - ToggleButton Component has its own state but it has not been passed to the onToggle, which requires us to create and maintain a separate state.
 - The onChange function is wrapped inside a useCallback which only has the dependency of toggleActive. This leads to the function forming a closure with the previous state value and leads to unwanted behaviour in some cases